### PR TITLE
Make signing optional

### DIFF
--- a/.github/workflows/fastlane.yml
+++ b/.github/workflows/fastlane.yml
@@ -1,6 +1,11 @@
 name: Validate fastlane metadata
 
-on: [ pull_request ]
+on:
+  pull_request:
+  push:
+    branches: [ "main" ]
+    paths: [ "fastlane/**" ]
+
 jobs:
   validate:
     runs-on: ubuntu-latest

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -3,6 +3,7 @@ name: Nightly build
 on:
   push:
     branches: [ "main" ]
+    paths-ignore: [ "docs/**", "fastlane/**", "**.md" ]
   workflow_dispatch:
 
 concurrency:
@@ -32,9 +33,17 @@ jobs:
           SIGN_KEY_ALIAS: ${{ secrets.SIGN_KEY_ALIAS }}
         run: ./gradlew assembleRelease
 
+      - name: Rename APK
+        run: |
+          set -e
+          SHA=${{ github.sha }}
+          echo "Release version is: $SHA"
+          
+          APK_DIR="app/build/outputs/apk/release"
+          mv ${APK_DIR}/app-release.apk NeoDB-You-nightly-${SHA}.apk
+
       - name: Upload APK
         uses: actions/upload-artifact@v4
         with:
-          name: arm64-v8a-${{ github.sha }}
-          path: app/build/outputs/apk/release/app-arm64-v8a-release.apk
-
+          name: nightly
+          path: app/build/outputs/apk/release/app-release.apk

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,8 @@ on:
   push:
     tags:
       - v*
-      
-jobs:   
+
+jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
@@ -37,12 +37,8 @@ jobs:
           echo "Release version is: $VERSION"
           
           APK_DIR="app/build/outputs/apk/release"
-          mv ${APK_DIR}/app-arm64-v8a-release.apk NeoDBYou-arm64-v8a-${VERSION}.apk
-          mv ${APK_DIR}/app-armeabi-v7a-release.apk NeoDBYou-armeabi-v7a-${VERSION}.apk
-          mv ${APK_DIR}/app-x86-release.apk NeoDBYou-x86-${VERSION}.apk
-          mv ${APK_DIR}/app-x86_64-release.apk NeoDBYou-x86_64-${VERSION}.apk
-          mv ${APK_DIR}/app-universal-release.apk NeoDBYou-universal-${VERSION}.apk
-          
+          mv ${APK_DIR}/app-release.apk NeoDB-You-${VERSION}.apk
+
       - name: Release
         uses: ncipollo/release-action@v1
         with:


### PR DESCRIPTION
Simply skip signing when key.properties doesn't exist and not in GitHub Actions,
in favor of IzzyOnDroid to confirm RB.

@IzzySoft sorry for the late reply. I Just tested on local machine and seems good.
And I also remove split block so maybe you should edit the sed script too.

Does it look good for you?