### PR TITLE
fix: propagate request failures instead of silently dropping them

### DIFF
--- a/.github/check.yml
+++ b/.github/check.yml
@@ -1,0 +1,48 @@
+# NOTE: This file is inert here. Activate it with:
+#   git mv .github/check.yml .github/workflows/check.yml
+# It was authored by an agent whose git credentials lack the `workflow` scope,
+# so it could not be pushed into .github/workflows/ directly.
+name: Check
+
+# Runs on every PR and on pushes to main and agent branches (claude/**),
+# so both humans and coding agents get fast feedback without opening a PR.
+on:
+  pull_request:
+    paths-ignore: [ "docs/**", "fastlane/**", "**.md" ]
+  push:
+    branches: [ "main", "claude/**" ]
+    paths-ignore: [ "docs/**", "fastlane/**", "**.md" ]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Setup Java JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: 21
+          distribution: temurin
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Unit tests
+        run: ./gradlew :app:testDebugUnitTest
+
+      - name: Lint
+        run: ./gradlew :app:lintDebug
+
+      - name: Upload reports on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: reports
+          path: app/build/reports/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,13 +12,18 @@ Coil 3 / Coroutines & Flow / DataStore。单模块项目（只有 `:app`，无�
 
 ```bash
 ./gradlew :app:compileDebugKotlin  # 只编译 Kotlin，最快的正确性检查
+./gradlew :app:testDebugUnitTest   # JVM 单元测试（app/src/test）
 ./gradlew assembleDebug            # Debug 构建（applicationId 后缀 .debug，可与正式版共存）
 ./gradlew assembleFastRelease      # Release 但跳过 R8/资源压缩/lint，用于快速验证
 ./gradlew assembleRelease          # 完整 Release（CI 使用；无 keystore.properties 时产出未签名 APK）
 ./gradlew lint                     # Android Lint
 ```
 
-- 项目**没有任何测试**（无 `src/test`、`src/androidTest`），不要找测试命令。
+- 单元测试是纯 JVM 的（无 `src/androidTest`，无模拟器）。`isReturnDefaultValues = true`：未 mock 的
+  `android.*` 方法（如 `android.util.Log`）返回默认值而不是抛异常；依赖真实 Android 框架的代码（如
+  `android.icu`、`android.net.Uri`）无法在单元测试覆盖，不要为它们写 JVM 测试。
+- 修改纯逻辑（`util/`、schema→model 映射、Repository 数据处理）时**应补充/更新对应单元测试**。
+- CI：`.github/workflows/check.yml` 在 PR 以及 `main`、`claude/**` 分支 push 时运行单元测试 + lint。
 - Ktlint **未接入 Gradle**：格式规则全在 `.editorconfig`（含 compose-rules 配置），`./gradlew lint`
   不检查格式。
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,8 @@ Coil 3 / Coroutines & Flow / DataStore。单模块项目（只有 `:app`，无�
   `android.*` 方法（如 `android.util.Log`）返回默认值而不是抛异常；依赖真实 Android 框架的代码（如
   `android.icu`、`android.net.Uri`）无法在单元测试覆盖，不要为它们写 JVM 测试。
 - 修改纯逻辑（`util/`、schema→model 映射、Repository 数据处理）时**应补充/更新对应单元测试**。
-- CI：`.github/workflows/check.yml` 在 PR 以及 `main`、`claude/**` 分支 push 时运行单元测试 + lint。
+- CI：`check.yml` 在 PR 以及 `main`、`claude/**` 分支 push 时运行单元测试 + lint。（文件暂位于
+  `.github/check.yml`，移入 `.github/workflows/` 后生效，见其头部注释。）
 - Ktlint **未接入 Gradle**：格式规则全在 `.editorconfig`（含 compose-rules 配置），`./gradlew lint`
   不检查格式。
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -94,6 +94,12 @@ android {
     @Suppress("UnstableApiUsage")
     androidResources.generateLocaleConfig = true
 
+    testOptions.unitTests {
+        // Unmocked android.* methods (e.g. android.util.Log) return default values
+        // instead of throwing, so pure logic passing through .log() is testable on JVM.
+        isReturnDefaultValues = true
+    }
+
     // https://developer.android.com/build/dependencies#dependency-info-play
     // https://gitlab.com/fdroid/fdroiddata/-/merge_requests/31338#note_2985399646
     dependenciesInfo {
@@ -151,6 +157,10 @@ dependencies {
     implementation(libs.androidx.browser)
     // Other
     implementation(libs.versionCompare)
+    // Test (JVM unit tests only, see app/src/test)
+    testImplementation(libs.junit)
+    testImplementation(libs.kotlin.test)
+    testImplementation(libs.kotlinx.coroutines.test)
 }
 
 // Signing config

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -94,11 +94,9 @@ android {
     @Suppress("UnstableApiUsage")
     androidResources.generateLocaleConfig = true
 
-    testOptions.unitTests {
-        // Unmocked android.* methods (e.g. android.util.Log) return default values
-        // instead of throwing, so pure logic passing through .log() is testable on JVM.
-        isReturnDefaultValues = true
-    }
+    // Unmocked android.* methods (e.g. android.util.Log) return default values
+    // instead of throwing, so pure logic passing through .log() is testable on JVM.
+    testOptions.unitTests.isReturnDefaultValues = true
 
     // https://developer.android.com/build/dependencies#dependency-info-play
     // https://gitlab.com/fdroid/fdroiddata/-/merge_requests/31338#note_2985399646

--- a/app/src/main/kotlin/day/vitayuzu/neodb/data/AuthRepository.kt
+++ b/app/src/main/kotlin/day/vitayuzu/neodb/data/AuthRepository.kt
@@ -84,9 +84,9 @@ class AuthRepository @Inject constructor(
             return Result.success(Pair(clientId, clientSecret))
         } else {
             Log.d("AuthRepository", "No saved auth client identification found, registering...")
-            runCatching {
+            return runCatching {
                 remoteSource.registerOauthAPP(instanceUrl)
-            }.onSuccess { oauthData ->
+            }.mapCatching { oauthData ->
                 with(appSettingsManager) {
                     store(INSTANCE_URL, instanceUrl)
                     store(CLIENT_ID, oauthData.clientId)
@@ -94,14 +94,11 @@ class AuthRepository @Inject constructor(
                 }
                 _accountStatus.update { it.copy(instanceUrl = instanceUrl) }
                 Log.d("AuthRepository", "Registered client saved")
-                return Result.success(Pair(oauthData.clientId, oauthData.clientSecret))
+                Pair(oauthData.clientId, oauthData.clientSecret)
             }.onFailure {
                 Log.e("AuthRepository", "Failed to register client", it)
             }
         }
-
-        Log.e("AuthRepository", "Failed to register app")
-        return Result.failure(Throwable())
     }
 
     /**

--- a/app/src/main/kotlin/day/vitayuzu/neodb/data/NeoDBRepository.kt
+++ b/app/src/main/kotlin/day/vitayuzu/neodb/data/NeoDBRepository.kt
@@ -10,11 +10,11 @@ import day.vitayuzu.neodb.util.ShelfType
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.flatMapMerge
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
 import javax.inject.Inject
 
@@ -81,4 +81,10 @@ fun <T> Flow<T>.log(msg: String, tag: String = "Repository") = this
         Log.e(tag, "Error fetching $msg: $it")
     }
 
-fun Flow<ResultSchema>.validate() = this.filter { it.message == "OK" }
+/**
+ * Throw if the server reports a non-OK result, so downstream (e.g. [log]) can observe the failure
+ * instead of treating it as a successful empty flow.
+ */
+fun Flow<ResultSchema>.validate() = this.onEach {
+    check(it.message == "OK") { "Server returned non-OK result: ${it.message}" }
+}

--- a/app/src/main/kotlin/day/vitayuzu/neodb/data/RemoteSource.kt
+++ b/app/src/main/kotlin/day/vitayuzu/neodb/data/RemoteSource.kt
@@ -95,12 +95,7 @@ class RemoteSource @Inject constructor(
     }
 
     suspend fun fetchDetail(type: EntryType, uuid: String) = withContext(dispatcher) {
-        val typeStringEndpoint = if (type == EntryType.music) {
-            "album"
-        } else {
-            type.toString()
-        }
-        api.fetchDetail(typeStringEndpoint, uuid)
+        api.fetchDetail(type.detailApiPath, uuid)
     }
 
     suspend fun fetchItemPosts(

--- a/app/src/main/kotlin/day/vitayuzu/neodb/ui/page/detail/DetailViewModel.kt
+++ b/app/src/main/kotlin/day/vitayuzu/neodb/ui/page/detail/DetailViewModel.kt
@@ -96,11 +96,12 @@ class DetailViewModel @AssistedInject constructor(
                 hasMorePost = false,
             )
         }
+        // Capture the previous job before reassignment: inside the new coroutine,
+        // loadingReviewsJob already points to the new job itself.
+        val previousJob = loadingReviewsJob
         loadingReviewsJob = viewModelScope.launch {
             // Cancel previous job
-            if (loadingReviewsJob?.isActive == true) {
-                loadingReviewsJob?.cancelAndJoin()
-            }
+            previousJob?.cancelAndJoin()
 
             @Suppress(
                 "ktlint:standard:chain-method-continuation",

--- a/app/src/main/kotlin/day/vitayuzu/neodb/util/EntryType.kt
+++ b/app/src/main/kotlin/day/vitayuzu/neodb/util/EntryType.kt
@@ -19,6 +19,13 @@ enum class EntryType {
     // Fanfic, Exhibition, Collection,
     default, ;
 
+    /**
+     * Path segment of the catalog detail endpoint (`/api/{path}/{uuid}`).
+     * Music is exposed as `album` there, unlike trending/search endpoints.
+     */
+    val detailApiPath: String
+        get() = if (this == music) "album" else name
+
     fun toR(): Int = when (this) {
         book -> R.string.entry_displayname_book
         movie -> R.string.entry_displayname_movie

--- a/app/src/test/kotlin/day/vitayuzu/neodb/data/NeoDBRepositoryTest.kt
+++ b/app/src/test/kotlin/day/vitayuzu/neodb/data/NeoDBRepositoryTest.kt
@@ -1,0 +1,195 @@
+package day.vitayuzu.neodb.data
+
+import day.vitayuzu.neodb.data.schema.AuthClientIdentify
+import day.vitayuzu.neodb.data.schema.EntrySchema
+import day.vitayuzu.neodb.data.schema.GithubLatestReleaseSchema
+import day.vitayuzu.neodb.data.schema.InstanceSchema
+import day.vitayuzu.neodb.data.schema.MarkInSchema
+import day.vitayuzu.neodb.data.schema.MarkSchema
+import day.vitayuzu.neodb.data.schema.PagedMarkSchema
+import day.vitayuzu.neodb.data.schema.PaginatedPostList
+import day.vitayuzu.neodb.data.schema.PublicInstanceSchema
+import day.vitayuzu.neodb.data.schema.ResultSchema
+import day.vitayuzu.neodb.data.schema.SearchResult
+import day.vitayuzu.neodb.data.schema.TokenSchema
+import day.vitayuzu.neodb.data.schema.UserPreferenceSchema
+import day.vitayuzu.neodb.data.schema.UserSchema
+import day.vitayuzu.neodb.data.schema.detail.DetailSchema
+import day.vitayuzu.neodb.util.EntryType
+import day.vitayuzu.neodb.util.ShelfType
+import io.ktor.client.request.HttpRequestBuilder
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class NeoDBRepositoryTest {
+
+    private fun TestScope.repositoryWith(api: NeoDbApi) =
+        NeoDBRepository(RemoteSource(api, StandardTestDispatcher(testScheduler)))
+
+    @Test
+    fun `pagedRequest fetches every page in order`() = runTest {
+        val requestedPages = mutableListOf<Int>()
+        val api = object : FakeNeoDbApi() {
+            override suspend fun searchWithKeywords(
+                keywords: String,
+                category: EntryType?,
+                page: Int,
+            ): SearchResult {
+                requestedPages += page
+                return SearchResult(data = emptyList(), pages = 3, count = 0)
+            }
+        }
+
+        val emissions = repositoryWith(api).searchWithKeyword("nausicaa").toList()
+
+        assertEquals(listOf(1, 2, 3), requestedPages)
+        assertEquals(3, emissions.size)
+    }
+
+    @Test
+    fun `pagedRequest stops after a single page`() = runTest {
+        val requestedPages = mutableListOf<Int>()
+        val api = object : FakeNeoDbApi() {
+            override suspend fun searchWithKeywords(
+                keywords: String,
+                category: EntryType?,
+                page: Int,
+            ): SearchResult {
+                requestedPages += page
+                return SearchResult(data = emptyList(), pages = 1, count = 0)
+            }
+        }
+
+        repositoryWith(api).searchWithKeyword("totoro").toList()
+
+        assertEquals(listOf(1), requestedPages)
+    }
+
+    @Test
+    fun `userShelf fetches all shelf types and all their pages`() = runTest {
+        val requested = mutableListOf<Pair<ShelfType, Int>>()
+        val api = object : FakeNeoDbApi() {
+            override suspend fun fetchMyShelf(type: ShelfType, page: Int): PagedMarkSchema {
+                requested += type to page
+                val pages = if (type == ShelfType.wishlist) 2 else 1
+                return PagedMarkSchema(data = null, count = 0, pages = pages)
+            }
+        }
+
+        val emissions = repositoryWith(api).userShelf.toList()
+
+        // 4 shelf types, wishlist has an extra page.
+        assertEquals(5, emissions.size)
+        val expected = ShelfType.entries.map { it to 1 }.toSet() + (ShelfType.wishlist to 2)
+        assertEquals(expected, requested.toSet())
+    }
+
+    @Test
+    fun `postMark emits the OK result`() = runTest {
+        val api = object : FakeNeoDbApi() {
+            override suspend fun postMark(uuid: String, data: MarkInSchema) = ResultSchema("OK")
+        }
+
+        val emissions = repositoryWith(api).postMark("uuid", MARK_IN).toList()
+
+        assertEquals(listOf(ResultSchema("OK")), emissions)
+    }
+
+    @Test
+    fun `postMark completes without emission when server reports failure`() = runTest {
+        val api = object : FakeNeoDbApi() {
+            override suspend fun postMark(uuid: String, data: MarkInSchema) =
+                ResultSchema("Something went wrong")
+        }
+
+        // validate() raises and log() records the failure; nothing is emitted downstream.
+        val emissions = repositoryWith(api).postMark("uuid", MARK_IN).toList()
+
+        assertEquals(emptyList(), emissions)
+    }
+
+    private companion object {
+        val MARK_IN = MarkInSchema(
+            shelfType = ShelfType.complete,
+            visibility = 0,
+            commentText = null,
+            ratingGrade = null,
+            tags = emptyList(),
+            createdTime = null,
+        )
+    }
+}
+
+/**
+ * Base fake for [NeoDbApi]: every endpoint fails loudly, tests override what they need.
+ */
+private open class FakeNeoDbApi : NeoDbApi {
+
+    override suspend fun fetchInstanceInfo(
+        instanceUrl: String,
+        ext: HttpRequestBuilder.() -> Unit,
+    ): InstanceSchema = unused()
+
+    override suspend fun registerOauthAPP(
+        clientName: String,
+        redirectUris: String,
+        website: String,
+        ext: HttpRequestBuilder.() -> Unit,
+    ): AuthClientIdentify = unused()
+
+    override suspend fun exchangeAccessToken(
+        clientId: String,
+        clientSecret: String,
+        code: String,
+        redirectUri: String,
+        grantType: String,
+        ext: HttpRequestBuilder.() -> Unit,
+    ): TokenSchema = unused()
+
+    override suspend fun revokeAccessToken(
+        clientId: String,
+        clientSecret: String,
+        token: String,
+        ext: HttpRequestBuilder.() -> Unit,
+    ): Unit = unused()
+
+    override suspend fun fetchMyShelf(type: ShelfType, page: Int): PagedMarkSchema = unused()
+
+    override suspend fun fetchTrending(type: EntryType): List<EntrySchema> = unused()
+
+    override suspend fun fetchDetail(type: String, uuid: String): DetailSchema = unused()
+
+    override suspend fun fetchItemPosts(
+        uuid: String,
+        type: String,
+        page: Int,
+    ): PaginatedPostList = unused()
+
+    override suspend fun fetchSelfAccountInfo(ext: HttpRequestBuilder.() -> Unit): UserSchema =
+        unused()
+
+    override suspend fun fetchSelfPreference(): UserPreferenceSchema = unused()
+
+    override suspend fun fetchItemUserMark(uuid: String): MarkSchema = unused()
+
+    override suspend fun postMark(uuid: String, data: MarkInSchema): ResultSchema = unused()
+
+    override suspend fun deleteMark(uuid: String): ResultSchema = unused()
+
+    override suspend fun searchWithKeywords(
+        keywords: String,
+        category: EntryType?,
+        page: Int,
+    ): SearchResult = unused()
+
+    override suspend fun getLatestVersionFromGithub(): GithubLatestReleaseSchema = unused()
+
+    override suspend fun fetchPublicInstances(): List<PublicInstanceSchema> = unused()
+
+    private fun unused(): Nothing =
+        throw UnsupportedOperationException("Endpoint not stubbed for this test")
+}

--- a/app/src/test/kotlin/day/vitayuzu/neodb/ui/model/MarkTest.kt
+++ b/app/src/test/kotlin/day/vitayuzu/neodb/ui/model/MarkTest.kt
@@ -1,0 +1,78 @@
+package day.vitayuzu.neodb.ui.model
+
+import day.vitayuzu.neodb.data.schema.EntrySchema
+import day.vitayuzu.neodb.data.schema.MarkSchema
+import day.vitayuzu.neodb.util.ShelfType
+import kotlinx.datetime.LocalDate
+import java.util.TimeZone
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class MarkTest {
+
+    private lateinit var originalTimeZone: TimeZone
+
+    @BeforeTest
+    fun fixTimeZone() {
+        originalTimeZone = TimeZone.getDefault()
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Shanghai"))
+    }
+
+    @AfterTest
+    fun restoreTimeZone() {
+        TimeZone.setDefault(originalTimeZone)
+    }
+
+    @Test
+    fun `created time is converted to a date in the local time zone`() {
+        // 2023-01-01T20:00Z is already 2023-01-02 in UTC+8.
+        val mark = Mark(markSchema(createdTime = "2023-01-01T20:00:00Z"), preferredLang = "en")
+        assertEquals(LocalDate(2023, 1, 2), mark.date)
+    }
+
+    @Test
+    fun `shelf type is parsed from its raw api name`() {
+        val mark = Mark(markSchema(shelfType = "progress"), preferredLang = "en")
+        assertEquals(ShelfType.progress, mark.shelfType)
+    }
+
+    @Test
+    fun `odd rating renders full stars and a half star`() {
+        val mark = Mark(markSchema(ratingGrade = 7), preferredLang = "en")
+        assertEquals(3, mark.fullStars)
+        assertTrue(mark.hasHalfStar)
+    }
+
+    @Test
+    fun `even rating renders only full stars`() {
+        val mark = Mark(markSchema(ratingGrade = 10), preferredLang = "en")
+        assertEquals(5, mark.fullStars)
+        assertFalse(mark.hasHalfStar)
+    }
+
+    @Test
+    fun `missing rating renders no stars`() {
+        val mark = Mark(markSchema(ratingGrade = null), preferredLang = "en")
+        assertEquals(0, mark.fullStars)
+        assertFalse(mark.hasHalfStar)
+    }
+
+    private fun markSchema(
+        createdTime: String = "2023-06-15T12:00:00Z",
+        shelfType: String = "complete",
+        ratingGrade: Int? = null,
+    ) = MarkSchema(
+        createdTime = createdTime,
+        commentText = null,
+        entrySchema = EntrySchema(category = "book", coverImageUrl = null),
+        visibility = 0,
+        postId = null,
+        ratingGrade = ratingGrade,
+        shelfType = shelfType,
+        tags = null,
+    )
+}

--- a/app/src/test/kotlin/day/vitayuzu/neodb/util/EntryTypeTest.kt
+++ b/app/src/test/kotlin/day/vitayuzu/neodb/util/EntryTypeTest.kt
@@ -1,0 +1,27 @@
+package day.vitayuzu.neodb.util
+
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class EntryTypeTest {
+
+    @Test
+    fun `detail api path maps music to album`() {
+        assertEquals("album", EntryType.music.detailApiPath)
+        assertEquals("book", EntryType.book.detailApiPath)
+        assertEquals("tv", EntryType.tv.detailApiPath)
+    }
+
+    // Enum names are used directly as API path segments, so they must stay lowercase.
+    @Test
+    fun `entry and shelf type names are lowercase`() {
+        val names = EntryType.entries.map { it.name } + ShelfType.entries.map { it.name }
+        names.forEach { assertEquals(it.lowercase(), it) }
+    }
+
+    @Test
+    fun `entry type serializes to its plain name`() {
+        assertEquals("\"book\"", Json.encodeToString(EntryType.serializer(), EntryType.book))
+    }
+}

--- a/app/src/test/kotlin/day/vitayuzu/neodb/util/LocalizeTest.kt
+++ b/app/src/test/kotlin/day/vitayuzu/neodb/util/LocalizeTest.kt
@@ -1,0 +1,71 @@
+package day.vitayuzu.neodb.util
+
+import day.vitayuzu.neodb.data.schema.detail.LocalizedData
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class LocalizeTest {
+
+    @Test
+    fun `exact language tag match wins`() {
+        val list = listOf(
+            LocalizedData("en", "English title"),
+            LocalizedData("zh-Hans", "简中标题"),
+        )
+        assertEquals("简中标题", list.display("zh-Hans"))
+    }
+
+    @Test
+    fun `same language matches when tags differ`() {
+        val list = listOf(
+            LocalizedData("en", "English title"),
+            LocalizedData("zh", "中文标题"),
+        )
+        assertEquals("中文标题", list.display("zh-Hans"))
+    }
+
+    @Test
+    fun `falls back to english when preferred language is missing`() {
+        val list = listOf(
+            LocalizedData("ja", "日本語タイトル"),
+            LocalizedData("en", "English title"),
+        )
+        assertEquals("English title", list.display("de"))
+    }
+
+    @Test
+    fun `falls back to first candidate when nothing matches`() {
+        val list = listOf(
+            LocalizedData("ja", "日本語タイトル"),
+            LocalizedData("fr", "Titre français"),
+        )
+        assertEquals("日本語タイトル", list.display("zh"))
+    }
+
+    @Test
+    fun `blank text is ignored`() {
+        val list = listOf(
+            LocalizedData("en", "   "),
+            LocalizedData("ja", "日本語タイトル"),
+        )
+        assertEquals("日本語タイトル", list.display("en"))
+    }
+
+    @Test
+    fun `invalid language tags are ignored`() {
+        val list = listOf(LocalizedData("", "mystery"))
+        assertNull(list.display("en"))
+    }
+
+    @Test
+    fun `empty list yields null`() {
+        assertNull(emptyList<LocalizedData>().display("en"))
+    }
+
+    @Test
+    fun `text is trimmed`() {
+        val list = listOf(LocalizedData("en", "  English title  "))
+        assertEquals("English title", list.display("en"))
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,6 +25,7 @@ versionCompare = "1.5.0"
 nav3 = "1.1.2"
 lifecycleViewmodelNav3 = "2.10.0"
 splashscreen = "1.2.0"
+junit = "4.13.2"
 
 [libraries]
 androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "coreKtx" }
@@ -60,6 +61,10 @@ androidx-navigation3-runtime = { module = "androidx.navigation3:navigation3-runt
 androidx-navigation3-ui = { module = "androidx.navigation3:navigation3-ui", version.ref = "nav3" }
 androidx-lifecycle-viewmodel-navigation3 = { module = "androidx.lifecycle:lifecycle-viewmodel-navigation3", version.ref = "lifecycleViewmodelNav3" }
 androidx-core-splashscreen = { module = "androidx.core:core-splashscreen", version.ref = "splashscreen" }
+# Test
+junit = { module = "junit:junit", version.ref = "junit" }
+kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinCoroutines" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
validate() used to filter out non-OK results, so a failed postMark/deleteMark
completed as an empty flow and the error was never observable (not even in
logs). It now throws, letting the .log() catch operator record the failure.

registerClientIfNeeded() returned Result.failure(Throwable()) with no message
or cause; it now propagates the actual exception to callers.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NLUaiKN1V3UkQxRX9995de