### PR TITLE
feat: add content language preference

### DIFF
--- a/app/src/main/kotlin/day/vitayuzu/neodb/data/AppSettingsManager.kt
+++ b/app/src/main/kotlin/day/vitayuzu/neodb/data/AppSettingsManager.kt
@@ -19,14 +19,17 @@ import day.vitayuzu.neodb.AppScope
 import day.vitayuzu.neodb.util.EntryType
 import day.vitayuzu.neodb.util.ShelfType
 import day.vitayuzu.neodb.util.USER_PREFERENCES
+import day.vitayuzu.neodb.util.toSupportedTag
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.SharingStarted.Companion.WhileSubscribed
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.serialization.json.Json
+import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -46,18 +49,18 @@ class AppSettingsManager @Inject constructor(
         .catch { e ->
             emit(emptyPreferences())
             Log.e("LocalSettingsManager", "Error while reading preferences", e)
-        }.map { preferences ->
-            val homeTrendingTypes = getAsList<EntryType>(HOME_TRENDING_TYPES)
-            val libraryShelfType =
-                ShelfType.valueOf(preferences[LIBRARY_SHELF_TYPE] ?: ShelfType.progress.name)
-            val verboseLog = preferences[VERBOSE_LOG] ?: false
-            val checkUpdate = preferences[CHECK_UPDATE] ?: false
-            AppSettings(homeTrendingTypes, libraryShelfType, verboseLog, checkUpdate)
-        }.stateIn(
+        }.map { it.toAppSettings() }.stateIn(
             scope = scope,
             started = WhileSubscribed(5000),
             initialValue = AppSettings(),
         )
+
+    suspend fun currentSettings(): AppSettings = dataStore.data
+        .catch { e ->
+            emit(emptyPreferences())
+            Log.e("LocalSettingsManager", "Error while reading preferences", e)
+        }.map { it.toAppSettings() }
+        .first()
 
     /**
      * Delete all local authentication.
@@ -90,12 +93,6 @@ class AppSettingsManager @Inject constructor(
         getAuthData(ACCESS_TOKEN),
     ).let { if (it.size == 4) it else null }
 
-    private suspend inline fun <reified T> getAsList(key: Preferences.Key<String>): List<T> =
-        dataStore.data
-            .map { Json.decodeFromString<List<T>>(it[key] ?: "[]") }
-            .catch { Log.e("AuthRepository", "Error while reading preferences ${key.name}", it) }
-            .firstOrNull() ?: emptyList()
-
     suspend fun <T> store(key: Preferences.Key<T>, value: T) {
         runCatching {
             dataStore.edit {
@@ -117,6 +114,44 @@ class AppSettingsManager @Inject constructor(
         }
     }
 
+    suspend fun storeContentLanguagePreference(
+        source: PreferredLanguageSource,
+        userLanguage: String,
+    ) {
+        dataStore.edit {
+            it[PREFERRED_LANGUAGE_SOURCE] = source.name
+            it[CONTENT_USER_LANGUAGE] = userLanguage
+        }
+    }
+
+    private fun Preferences.toAppSettings(): AppSettings {
+        val homeTrendingTypes = this[HOME_TRENDING_TYPES]?.let { encoded ->
+            runCatching { Json.decodeFromString<List<EntryType>>(encoded) }
+                .onFailure {
+                    Log.e(
+                        "LocalSettingsManager",
+                        "Error while reading preferences ${HOME_TRENDING_TYPES.name}",
+                        it,
+                    )
+                }.getOrDefault(emptyList())
+        }
+        val libraryShelfType = this[LIBRARY_SHELF_TYPE]?.let { stored ->
+            ShelfType.entries.find { it.name == stored }
+        }
+        val languageSource = this[PREFERRED_LANGUAGE_SOURCE]?.let { stored ->
+            PreferredLanguageSource.entries.find { it.name == stored }
+        }
+
+        return AppSettings(
+            homeTrendingTypes = homeTrendingTypes,
+            libraryShelfType = libraryShelfType,
+            preferredLanguageSource = languageSource,
+            contentUserLanguage = this[CONTENT_USER_LANGUAGE],
+            verboseLog = this[VERBOSE_LOG],
+            checkUpdate = this[CHECK_UPDATE],
+        )
+    }
+
     companion object {
         val INSTANCE_URL = stringPreferencesKey("instance_url")
         val CLIENT_ID = stringPreferencesKey("client_id")
@@ -126,6 +161,8 @@ class AppSettingsManager @Inject constructor(
         // Settings
         val HOME_TRENDING_TYPES = stringPreferencesKey("home_trending_types")
         val LIBRARY_SHELF_TYPE = stringPreferencesKey("library_shelf_type")
+        val PREFERRED_LANGUAGE_SOURCE = stringPreferencesKey("preferred_language_source")
+        val CONTENT_USER_LANGUAGE = stringPreferencesKey("content_user_language")
 
         // TODO: Control global log level
         val VERBOSE_LOG = booleanPreferencesKey("verbose_log")
@@ -139,10 +176,31 @@ class AppSettingsManager @Inject constructor(
 @Suppress("ktlint:standard:max-line-length")
 data class AppSettings(
     val homeTrendingTypes: List<EntryType> = emptyList(), // enabled trending types for home
-    val libraryShelfType: ShelfType = ShelfType.wishlist, // preferred/default shelf type for library
+    val libraryShelfType: ShelfType = ShelfType.progress, // preferred/default shelf type for library
+    val preferredLanguageSource: PreferredLanguageSource = PreferredLanguageSource.Server,
+    val contentUserLanguage: String = Locale.getDefault().toSupportedTag(), // specify for PreferredLanguageSource.User
     val verboseLog: Boolean = false,
     val checkUpdate: Boolean = false, // disabled by default
-)
+) {
+    // Make null fields have default value
+    constructor(
+        homeTrendingTypes: List<EntryType>?,
+        libraryShelfType: ShelfType?,
+        preferredLanguageSource: PreferredLanguageSource?,
+        contentUserLanguage: String?,
+        verboseLog: Boolean?,
+        checkUpdate: Boolean?,
+    ) : this(
+        homeTrendingTypes ?: emptyList(),
+        libraryShelfType ?: ShelfType.progress,
+        preferredLanguageSource ?: PreferredLanguageSource.Server,
+        contentUserLanguage ?: Locale.getDefault().toSupportedTag(),
+        verboseLog ?: false,
+        checkUpdate ?: false,
+    )
+}
+
+enum class PreferredLanguageSource { Server, App, User }
 
 @Module
 @InstallIn(SingletonComponent::class)

--- a/app/src/main/kotlin/day/vitayuzu/neodb/data/AppSettingsManager.kt
+++ b/app/src/main/kotlin/day/vitayuzu/neodb/data/AppSettingsManager.kt
@@ -55,6 +55,7 @@ class AppSettingsManager @Inject constructor(
             initialValue = AppSettings(),
         )
 
+    /** Reads the persisted snapshot; [appSettings] may still hold its initial value without collectors. */
     suspend fun currentSettings(): AppSettings = dataStore.data
         .catch { e ->
             emit(emptyPreferences())
@@ -115,42 +116,46 @@ class AppSettingsManager @Inject constructor(
     }
 
     suspend fun storeContentLanguagePreference(
-        source: PreferredLanguageSource,
-        userLanguage: String,
+        source: ContentLanguageSource,
+        customLanguage: String,
     ) {
         dataStore.edit {
-            it[PREFERRED_LANGUAGE_SOURCE] = source.name
-            it[CONTENT_USER_LANGUAGE] = userLanguage
+            it[CONTENT_LANGUAGE_SOURCE] = source.name
+            it[CUSTOM_CONTENT_LANGUAGE] = customLanguage
         }
     }
 
     private fun Preferences.toAppSettings(): AppSettings {
-        val homeTrendingTypes = this[HOME_TRENDING_TYPES]?.let { encoded ->
-            runCatching { Json.decodeFromString<List<EntryType>>(encoded) }
-                .onFailure {
-                    Log.e(
-                        "LocalSettingsManager",
-                        "Error while reading preferences ${HOME_TRENDING_TYPES.name}",
-                        it,
-                    )
-                }.getOrDefault(emptyList())
-        }
+        val homeTrendingTypes = getAsList<EntryType>(HOME_TRENDING_TYPES)
         val libraryShelfType = this[LIBRARY_SHELF_TYPE]?.let { stored ->
             ShelfType.entries.find { it.name == stored }
         }
-        val languageSource = this[PREFERRED_LANGUAGE_SOURCE]?.let { stored ->
-            PreferredLanguageSource.entries.find { it.name == stored }
+        val languageSource = this[CONTENT_LANGUAGE_SOURCE]?.let { stored ->
+            ContentLanguageSource.entries.find { it.name == stored }
         }
 
         return AppSettings(
             homeTrendingTypes = homeTrendingTypes,
             libraryShelfType = libraryShelfType,
-            preferredLanguageSource = languageSource,
-            contentUserLanguage = this[CONTENT_USER_LANGUAGE],
+            contentLanguageSource = languageSource,
+            customContentLanguage = this[CUSTOM_CONTENT_LANGUAGE],
             verboseLog = this[VERBOSE_LOG],
             checkUpdate = this[CHECK_UPDATE],
         )
     }
+
+    private inline fun <reified T> Preferences.getAsList(
+        key: Preferences.Key<String>,
+    ): List<T> = this[key]?.let { encoded ->
+        runCatching { Json.decodeFromString<List<T>>(encoded) }
+            .onFailure {
+                Log.e(
+                    "LocalSettingsManager",
+                    "Error while reading preferences ${key.name}",
+                    it,
+                )
+            }.getOrDefault(emptyList())
+    } ?: emptyList()
 
     companion object {
         val INSTANCE_URL = stringPreferencesKey("instance_url")
@@ -161,8 +166,8 @@ class AppSettingsManager @Inject constructor(
         // Settings
         val HOME_TRENDING_TYPES = stringPreferencesKey("home_trending_types")
         val LIBRARY_SHELF_TYPE = stringPreferencesKey("library_shelf_type")
-        val PREFERRED_LANGUAGE_SOURCE = stringPreferencesKey("preferred_language_source")
-        val CONTENT_USER_LANGUAGE = stringPreferencesKey("content_user_language")
+        val CONTENT_LANGUAGE_SOURCE = stringPreferencesKey("content_language_source")
+        val CUSTOM_CONTENT_LANGUAGE = stringPreferencesKey("custom_content_language")
 
         // TODO: Control global log level
         val VERBOSE_LOG = booleanPreferencesKey("verbose_log")
@@ -176,9 +181,9 @@ class AppSettingsManager @Inject constructor(
 @Suppress("ktlint:standard:max-line-length")
 data class AppSettings(
     val homeTrendingTypes: List<EntryType> = emptyList(), // enabled trending types for home
-    val libraryShelfType: ShelfType = ShelfType.progress, // preferred/default shelf type for library
-    val preferredLanguageSource: PreferredLanguageSource = PreferredLanguageSource.Server,
-    val contentUserLanguage: String = Locale.getDefault().toSupportedTag(), // specify for PreferredLanguageSource.User
+    val libraryShelfType: ShelfType = ShelfType.wishlist, // preferred/default shelf type for library
+    val contentLanguageSource: ContentLanguageSource = ContentLanguageSource.Server,
+    val customContentLanguage: String = Locale.getDefault().toSupportedTag(),
     val verboseLog: Boolean = false,
     val checkUpdate: Boolean = false, // disabled by default
 ) {
@@ -186,21 +191,21 @@ data class AppSettings(
     constructor(
         homeTrendingTypes: List<EntryType>?,
         libraryShelfType: ShelfType?,
-        preferredLanguageSource: PreferredLanguageSource?,
-        contentUserLanguage: String?,
+        contentLanguageSource: ContentLanguageSource?,
+        customContentLanguage: String?,
         verboseLog: Boolean?,
         checkUpdate: Boolean?,
     ) : this(
         homeTrendingTypes ?: emptyList(),
         libraryShelfType ?: ShelfType.progress,
-        preferredLanguageSource ?: PreferredLanguageSource.Server,
-        contentUserLanguage ?: Locale.getDefault().toSupportedTag(),
+        contentLanguageSource ?: ContentLanguageSource.Server,
+        customContentLanguage ?: Locale.getDefault().toSupportedTag(),
         verboseLog ?: false,
         checkUpdate ?: false,
     )
 }
 
-enum class PreferredLanguageSource { Server, App, User }
+enum class ContentLanguageSource { Server, App, User }
 
 @Module
 @InstallIn(SingletonComponent::class)

--- a/app/src/main/kotlin/day/vitayuzu/neodb/data/NetworkHiltModule.kt
+++ b/app/src/main/kotlin/day/vitayuzu/neodb/data/NetworkHiltModule.kt
@@ -7,9 +7,11 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import day.vitayuzu.neodb.data.AppSettingsManager.Companion.VERBOSE_LOG
 import day.vitayuzu.neodb.util.BASE_URL
+import day.vitayuzu.neodb.util.toSupportedTag
 import de.jensklingenberg.ktorfit.Ktorfit
 import de.jensklingenberg.ktorfit.ktorfit
 import io.ktor.client.HttpClient
+import io.ktor.client.plugins.HttpSend
 import io.ktor.client.plugins.auth.Auth
 import io.ktor.client.plugins.auth.providers.BearerTokens
 import io.ktor.client.plugins.auth.providers.bearer
@@ -19,6 +21,7 @@ import io.ktor.client.plugins.logging.ANDROID
 import io.ktor.client.plugins.logging.LogLevel
 import io.ktor.client.plugins.logging.Logger
 import io.ktor.client.plugins.logging.Logging
+import io.ktor.client.plugins.plugin
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.encodedPath
@@ -26,6 +29,7 @@ import io.ktor.serialization.kotlinx.json.json
 import io.ktor.util.appendIfNameAbsent
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
+import java.util.Locale
 import javax.inject.Singleton
 
 @Module
@@ -42,7 +46,7 @@ object NetworkHiltModule {
         appSettings: AppSettingsManager,
         userPreference: dagger.Lazy<UserPreferenceManager>, // avoid dependency cycle
     ): Ktorfit = ktorfit {
-        httpClient(
+        val client =
             HttpClient {
                 baseUrl("https://$BASE_URL/api/") // using https://neodb.social/api as default
                 install(Logging) {
@@ -59,12 +63,6 @@ object NetworkHiltModule {
                     headers.appendIfNameAbsent(
                         HttpHeaders.ContentType,
                         ContentType.Application.Json.toString(),
-                    )
-                    headers.appendIfNameAbsent(
-                        HttpHeaders.AcceptLanguage,
-                        userPreference
-                            .get()
-                            .preference.value.language,
                     )
                 }
                 install(ContentNegotiation) {
@@ -101,7 +99,19 @@ object NetworkHiltModule {
                         }
                     }
                 }
-            },
-        )
+            }
+        client.plugin(HttpSend).intercept { request ->
+            val settings = appSettings.currentSettings()
+            val language = when (settings.preferredLanguageSource) {
+                PreferredLanguageSource.Server -> userPreference.get().serverLanguage(
+                    awaitPreference = !request.url.encodedPath.endsWith("/me/preference"),
+                )
+                PreferredLanguageSource.App -> Locale.getDefault().toSupportedTag()
+                PreferredLanguageSource.User -> settings.contentUserLanguage
+            }
+            request.headers.appendIfNameAbsent(HttpHeaders.AcceptLanguage, language)
+            execute(request)
+        }
+        httpClient(client)
     }
 }

--- a/app/src/main/kotlin/day/vitayuzu/neodb/data/NetworkHiltModule.kt
+++ b/app/src/main/kotlin/day/vitayuzu/neodb/data/NetworkHiltModule.kt
@@ -49,9 +49,14 @@ object NetworkHiltModule {
             onRequest { request, _ ->
                 val settings = appSettings.currentSettings()
                 val language = when (settings.contentLanguageSource) {
-                    ContentLanguageSource.Server -> userPreference.get().serverLanguage(
-                        awaitPreference = !request.url.encodedPath.endsWith("/me/preference"),
-                    )
+                    ContentLanguageSource.Server -> if (
+                        request.url.encodedPath.endsWith("/me/preference")
+                    ) {
+                        // This request makes the server language ready, so it cannot await itself.
+                        userPreference.get().currentLanguage()
+                    } else {
+                        userPreference.get().serverLanguage()
+                    }
                     ContentLanguageSource.App -> Locale.getDefault().toSupportedTag()
                     ContentLanguageSource.User -> settings.customContentLanguage
                 }

--- a/app/src/main/kotlin/day/vitayuzu/neodb/data/NetworkHiltModule.kt
+++ b/app/src/main/kotlin/day/vitayuzu/neodb/data/NetworkHiltModule.kt
@@ -11,7 +11,7 @@ import day.vitayuzu.neodb.util.toSupportedTag
 import de.jensklingenberg.ktorfit.Ktorfit
 import de.jensklingenberg.ktorfit.ktorfit
 import io.ktor.client.HttpClient
-import io.ktor.client.plugins.HttpSend
+import io.ktor.client.plugins.api.createClientPlugin
 import io.ktor.client.plugins.auth.Auth
 import io.ktor.client.plugins.auth.providers.BearerTokens
 import io.ktor.client.plugins.auth.providers.bearer
@@ -21,7 +21,6 @@ import io.ktor.client.plugins.logging.ANDROID
 import io.ktor.client.plugins.logging.LogLevel
 import io.ktor.client.plugins.logging.Logger
 import io.ktor.client.plugins.logging.Logging
-import io.ktor.client.plugins.plugin
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.encodedPath
@@ -46,9 +45,23 @@ object NetworkHiltModule {
         appSettings: AppSettingsManager,
         userPreference: dagger.Lazy<UserPreferenceManager>, // avoid dependency cycle
     ): Ktorfit = ktorfit {
-        val client =
+        val contentLanguagePlugin = createClientPlugin("ContentLanguage") {
+            onRequest { request, _ ->
+                val settings = appSettings.currentSettings()
+                val language = when (settings.contentLanguageSource) {
+                    ContentLanguageSource.Server -> userPreference.get().serverLanguage(
+                        awaitPreference = !request.url.encodedPath.endsWith("/me/preference"),
+                    )
+                    ContentLanguageSource.App -> Locale.getDefault().toSupportedTag()
+                    ContentLanguageSource.User -> settings.customContentLanguage
+                }
+                request.headers.appendIfNameAbsent(HttpHeaders.AcceptLanguage, language)
+            }
+        }
+        httpClient(
             HttpClient {
                 baseUrl("https://$BASE_URL/api/") // using https://neodb.social/api as default
+                install(contentLanguagePlugin)
                 install(Logging) {
                     logger = Logger.ANDROID
                     runBlocking {
@@ -99,19 +112,7 @@ object NetworkHiltModule {
                         }
                     }
                 }
-            }
-        client.plugin(HttpSend).intercept { request ->
-            val settings = appSettings.currentSettings()
-            val language = when (settings.preferredLanguageSource) {
-                PreferredLanguageSource.Server -> userPreference.get().serverLanguage(
-                    awaitPreference = !request.url.encodedPath.endsWith("/me/preference"),
-                )
-                PreferredLanguageSource.App -> Locale.getDefault().toSupportedTag()
-                PreferredLanguageSource.User -> settings.contentUserLanguage
-            }
-            request.headers.appendIfNameAbsent(HttpHeaders.AcceptLanguage, language)
-            execute(request)
-        }
-        httpClient(client)
+            },
+        )
     }
 }

--- a/app/src/main/kotlin/day/vitayuzu/neodb/data/UserPreferenceManager.kt
+++ b/app/src/main/kotlin/day/vitayuzu/neodb/data/UserPreferenceManager.kt
@@ -2,12 +2,15 @@ package day.vitayuzu.neodb.data
 
 import android.util.Log
 import day.vitayuzu.neodb.AppScope
+import day.vitayuzu.neodb.data.AppSettingsManager.Companion.ACCESS_TOKEN
 import day.vitayuzu.neodb.data.schema.UserPreferenceSchema
 import day.vitayuzu.neodb.util.EntryType
+import day.vitayuzu.neodb.util.toSupportedTag
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.distinctUntilChangedBy
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
@@ -22,12 +25,15 @@ import javax.inject.Singleton
 @Singleton
 class UserPreferenceManager @Inject constructor(
     private val remoteSource: RemoteSource,
-    authRepo: AuthRepository,
+    private val authRepo: AuthRepository,
+    private val appSettingsManager: AppSettingsManager,
     @AppScope scope: CoroutineScope,
 ) {
 
     val preference: StateFlow<UserPreference>
         field = MutableStateFlow(UserPreference())
+
+    private val serverPreferenceReady = MutableStateFlow(false)
 
     init {
         authRepo.accountStatus
@@ -42,6 +48,7 @@ class UserPreferenceManager @Inject constructor(
     }
 
     suspend fun refresh() {
+        serverPreferenceReady.value = false
         runCatching {
             Log.d("UserPreferenceRepository", "Start fetching user preference")
             preference.update { it.copy(loading = true) }
@@ -53,6 +60,16 @@ class UserPreferenceManager @Inject constructor(
             Log.e("UserPreferenceRepository", "Error fetching user preference: $error")
         }
         preference.update { it.copy(loading = false) }
+        serverPreferenceReady.value = true
+    }
+
+    suspend fun serverLanguage(awaitPreference: Boolean): String {
+        val isLoggedIn = appSettingsManager.getAuthData(ACCESS_TOKEN) != null
+        if (!isLoggedIn) {
+            return Locale.getDefault().toSupportedTag()
+        }
+        if (awaitPreference) serverPreferenceReady.first { it }
+        return preference.value.language
     }
 
     private fun reset() {

--- a/app/src/main/kotlin/day/vitayuzu/neodb/data/UserPreferenceManager.kt
+++ b/app/src/main/kotlin/day/vitayuzu/neodb/data/UserPreferenceManager.kt
@@ -2,19 +2,19 @@ package day.vitayuzu.neodb.data
 
 import android.util.Log
 import day.vitayuzu.neodb.AppScope
-import day.vitayuzu.neodb.data.AppSettingsManager.Companion.ACCESS_TOKEN
 import day.vitayuzu.neodb.data.schema.UserPreferenceSchema
 import day.vitayuzu.neodb.util.EntryType
 import day.vitayuzu.neodb.util.toSupportedTag
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.distinctUntilChangedBy
-import kotlinx.coroutines.flow.filterNotNull
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -34,14 +34,15 @@ class UserPreferenceManager @Inject constructor(
     val preference: StateFlow<UserPreference>
         field = MutableStateFlow(UserPreference())
 
-    private val serverContentLanguage = MutableStateFlow<String?>(null)
+    private val refreshMutex = Mutex()
+    private var serverContentLanguage: String? = null
 
     init {
         authRepo.accountStatus
             .distinctUntilChangedBy { it.isLogin }
             .onEach {
                 if (it.isLogin) {
-                    refresh()
+                    ensureServerLanguage()
                 } else {
                     reset()
                 }
@@ -49,34 +50,50 @@ class UserPreferenceManager @Inject constructor(
     }
 
     suspend fun refresh() {
-        serverContentLanguage.value = null
-        runCatching {
-            Log.d("UserPreferenceRepository", "Start fetching user preference")
-            preference.update { it.copy(loading = true) }
-            remoteSource.fetchSelfPreference()
-        }.onSuccess { schema ->
-            Log.d("UserPreferenceRepository", "End fetching user preference:$schema")
-            preference.value = UserPreference(schema)
-            serverContentLanguage.value = schema.language
-        }.onFailure { error ->
-            Log.e("UserPreferenceRepository", "Error fetching user preference: $error")
-            serverContentLanguage.value = preference.value.language
+        refreshMutex.withLock { refreshLocked() }
+    }
+
+    private suspend fun ensureServerLanguage(): String = refreshMutex.withLock {
+        serverContentLanguage ?: refreshLocked()
+    }
+
+    private suspend fun refreshLocked(): String {
+        serverContentLanguage = null
+        Log.d("UserPreferenceRepository", "Start fetching user preference")
+        preference.update { it.copy(loading = true) }
+        try {
+            val language = try {
+                val schema = remoteSource.fetchSelfPreference()
+                Log.d("UserPreferenceRepository", "End fetching user preference:$schema")
+                preference.value = UserPreference(schema)
+                schema.language
+            } catch (error: CancellationException) {
+                throw error
+            } catch (error: Exception) {
+                Log.e("UserPreferenceRepository", "Error fetching user preference: $error")
+                preference.value.language
+            }
+            serverContentLanguage = language
+            return language
+        } finally {
+            preference.update { current -> current.copy(loading = false) }
         }
-        preference.update { it.copy(loading = false) }
     }
 
     suspend fun serverLanguage(): String {
-        val isLoggedIn = appSettingsManager.getAuthData(ACCESS_TOKEN) != null
-        if (!isLoggedIn) {
+        if (appSettingsManager.getAllAuthData() == null) {
             return Locale.getDefault().toSupportedTag()
         }
-        return serverContentLanguage.filterNotNull().first()
+        return ensureServerLanguage()
     }
 
     fun currentLanguage(): String = preference.value.language
 
-    private fun reset() {
-        preference.value = UserPreference()
+    private suspend fun reset() {
+        refreshMutex.withLock {
+            serverContentLanguage = null
+            preference.value = UserPreference()
+        }
     }
 }
 
@@ -85,7 +102,7 @@ data class UserPreference(
     val crossPost: Boolean = true,
     val visibility: Int = 0,
     val hiddenSearchCategories: List<EntryType> = emptyList(),
-    val language: String = Locale.getDefault().toLanguageTag(),
+    val language: String = Locale.getDefault().toSupportedTag(),
 ) {
     constructor(schema: UserPreferenceSchema) : this(
         loading = false,

--- a/app/src/main/kotlin/day/vitayuzu/neodb/data/UserPreferenceManager.kt
+++ b/app/src/main/kotlin/day/vitayuzu/neodb/data/UserPreferenceManager.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.distinctUntilChangedBy
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -33,7 +34,7 @@ class UserPreferenceManager @Inject constructor(
     val preference: StateFlow<UserPreference>
         field = MutableStateFlow(UserPreference())
 
-    private val serverPreferenceReady = MutableStateFlow(false)
+    private val serverContentLanguage = MutableStateFlow<String?>(null)
 
     init {
         authRepo.accountStatus
@@ -48,7 +49,7 @@ class UserPreferenceManager @Inject constructor(
     }
 
     suspend fun refresh() {
-        serverPreferenceReady.value = false
+        serverContentLanguage.value = null
         runCatching {
             Log.d("UserPreferenceRepository", "Start fetching user preference")
             preference.update { it.copy(loading = true) }
@@ -56,11 +57,12 @@ class UserPreferenceManager @Inject constructor(
         }.onSuccess { schema ->
             Log.d("UserPreferenceRepository", "End fetching user preference:$schema")
             preference.value = UserPreference(schema)
+            serverContentLanguage.value = schema.language
         }.onFailure { error ->
             Log.e("UserPreferenceRepository", "Error fetching user preference: $error")
+            serverContentLanguage.value = preference.value.language
         }
         preference.update { it.copy(loading = false) }
-        serverPreferenceReady.value = true
     }
 
     suspend fun serverLanguage(): String {
@@ -68,9 +70,7 @@ class UserPreferenceManager @Inject constructor(
         if (!isLoggedIn) {
             return Locale.getDefault().toSupportedTag()
         }
-        // Avoid sending other cold-start requests with the local fallback before refresh finishes.
-        serverPreferenceReady.first { ready -> ready }
-        return preference.value.language
+        return serverContentLanguage.filterNotNull().first()
     }
 
     fun currentLanguage(): String = preference.value.language

--- a/app/src/main/kotlin/day/vitayuzu/neodb/data/UserPreferenceManager.kt
+++ b/app/src/main/kotlin/day/vitayuzu/neodb/data/UserPreferenceManager.kt
@@ -63,14 +63,17 @@ class UserPreferenceManager @Inject constructor(
         serverPreferenceReady.value = true
     }
 
-    suspend fun serverLanguage(awaitPreference: Boolean): String {
+    suspend fun serverLanguage(): String {
         val isLoggedIn = appSettingsManager.getAuthData(ACCESS_TOKEN) != null
         if (!isLoggedIn) {
             return Locale.getDefault().toSupportedTag()
         }
-        if (awaitPreference) serverPreferenceReady.first { it }
+        // Avoid sending other cold-start requests with the local fallback before refresh finishes.
+        serverPreferenceReady.first { ready -> ready }
         return preference.value.language
     }
+
+    fun currentLanguage(): String = preference.value.language
 
     private fun reset() {
         preference.value = UserPreference()

--- a/app/src/main/kotlin/day/vitayuzu/neodb/ui/component/ConnectedButtonGroup.kt
+++ b/app/src/main/kotlin/day/vitayuzu/neodb/ui/component/ConnectedButtonGroup.kt
@@ -1,77 +1,324 @@
+@file:Suppress("MayBeConstant")
+
 package day.vitayuzu.neodb.ui.component
 
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.material3.ButtonGroupDefaults
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.selection.selectableGroup
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.ToggleButtonColors
 import androidx.compose.material3.ToggleButtonDefaults
+import androidx.compose.material3.ToggleButtonShapes
 import androidx.compose.material3.TonalToggleButton
+import androidx.compose.material3.contentColorFor
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.compositeOver
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.lerp
+import androidx.compose.ui.graphics.takeOrElse
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.takeOrElse
 import day.vitayuzu.neodb.ui.theme.NeoDBYouTheme
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun ConnectedButtonGroup(
-    optionNumber: Int,
-    selectedOption: Int,
-    onSelectedChange: (Int) -> Unit,
-    optionContent: @Composable (Int) -> Unit,
     modifier: Modifier = Modifier,
-    colors: @Composable (Int) -> ToggleButtonColors = {
-        ToggleButtonDefaults.tonalToggleButtonColors()
-    },
+    columns: Int = Int.MAX_VALUE,
+    spacing: Dp = GroupSpacing,
+    checkedWeight: Float = MultiCheckedWeight,
+    content: ConnectedButtonGroupScope.() -> Unit,
 ) {
-    Row(
-        modifier = modifier,
-        horizontalArrangement = Arrangement.spacedBy(
-            ButtonGroupDefaults.ConnectedSpaceBetween,
-        ),
-    ) {
-        for (index in 0 until optionNumber) {
-            TonalToggleButton(
-                checked = selectedOption == index,
-                onCheckedChange = { onSelectedChange(index) },
-                modifier = Modifier.semantics { role = Role.RadioButton },
-                colors = colors(index),
-                shapes =
-                    when (index) {
-                        0 -> {
-                            ButtonGroupDefaults.connectedLeadingButtonShapes()
-                        }
-
-                        optionNumber - 1 -> {
-                            ButtonGroupDefaults.connectedTrailingButtonShapes()
-                        }
-
-                        else -> {
-                            ButtonGroupDefaults.connectedMiddleButtonShapes()
-                        }
-                    },
-            ) {
-                optionContent(index)
+    val items = ConnectedButtonGroupScopeImpl().apply(content).items
+    items.chunked(columns).forEach { row ->
+        Row(
+            modifier = modifier,
+            horizontalArrangement = Arrangement.spacedBy(spacing),
+        ) {
+            row.forEachIndexed { index, item ->
+                ConnectedButton(
+                    item = item,
+                    isFirst = index == 0,
+                    isLast = index == row.lastIndex,
+                    checkedWeight = checkedWeight,
+                )
+            }
+            if (columns != Int.MAX_VALUE) {
+                val missing = columns - row.size
+                if (missing > 0) {
+                    Spacer(Modifier.weight(missing.toFloat()))
+                }
             }
         }
     }
+}
+
+/**
+ * Single-choice [ConnectedButtonGroup].
+ *
+ * [selected] is matched against [options] by structural equality ([Any.equals]),
+ * so [T] should be a value type (enum, data class, String, ...) and [options]
+ * should not contain duplicates.
+ */
+@Composable
+fun <T> ConnectedButtonGroup(
+    options: List<T>,
+    selected: T,
+    onSelectedChange: (T) -> Unit,
+    modifier: Modifier = Modifier,
+    spacing: Dp = GroupSpacing,
+    checkedWeight: Float = SingleCheckedWeight,
+    accent: @Composable (T) -> Color = { MaterialTheme.colorScheme.primary },
+    optionContent: @Composable (T) -> Unit,
+) {
+    val accents = options.map { accent(it) }
+    ConnectedButtonGroup(
+        modifier = modifier.selectableGroup(),
+        spacing = spacing,
+        checkedWeight = checkedWeight,
+    ) {
+        options.forEachIndexed { index, option ->
+            item(
+                checked = option == selected,
+                onCheckedChange = { onSelectedChange(option) },
+                modifier = Modifier.semantics { role = Role.RadioButton },
+                accent = accents[index],
+            ) { optionContent(option) }
+        }
+    }
+}
+
+interface ConnectedButtonGroupScope {
+    /**
+     * A toggle button of the group.
+     *
+     * @param accent container color when checked, also tinting the unchecked state.
+     * [Color.Unspecified] falls back to the theme's primary color.
+     * @param shapes overrides the default [connectedShapes], e.g. to tighten corners
+     * toward a panel attached below the button. `null` uses the default.
+     * @param colors overrides the default tonal colors, e.g. for a group placed on
+     * a colored container where the accent-over-surface scheme doesn't work.
+     * `null` uses the default derived from [accent].
+     */
+    fun item(
+        checked: Boolean,
+        onCheckedChange: (Boolean) -> Unit,
+        modifier: Modifier = Modifier,
+        enabled: Boolean = true,
+        accent: Color = Color.Unspecified,
+        shapes: ToggleButtonShapes? = null,
+        colors: ToggleButtonColors? = null,
+        content: @Composable () -> Unit,
+    )
+}
+
+private class ConnectedButtonGroupScopeImpl : ConnectedButtonGroupScope {
+    val items = mutableListOf<ConnectedButtonItem>()
+
+    override fun item(
+        checked: Boolean,
+        onCheckedChange: (Boolean) -> Unit,
+        modifier: Modifier,
+        enabled: Boolean,
+        accent: Color,
+        shapes: ToggleButtonShapes?,
+        colors: ToggleButtonColors?,
+        content: @Composable () -> Unit,
+    ) {
+        items +=
+            ConnectedButtonItem(
+                checked,
+                onCheckedChange,
+                modifier,
+                enabled,
+                accent,
+                shapes,
+                colors,
+                content,
+            )
+    }
+}
+
+private class ConnectedButtonItem(
+    val checked: Boolean,
+    val onCheckedChange: (Boolean) -> Unit,
+    val modifier: Modifier,
+    val enabled: Boolean,
+    val accent: Color,
+    val shapes: ToggleButtonShapes?,
+    val colors: ToggleButtonColors?,
+    val content: @Composable () -> Unit,
+)
+
+private val GroupSpacing = 8.dp
+private val CheckedCorner = 12.dp
+private val OuterCorner = 12.dp
+private val InnerCorner = 8.dp
+private val PressedCorner = 16.dp
+private val SingleCheckedWeight = 2f
+private val MultiCheckedWeight = 1.4f
+private val PressedWeight = 1.15f
+private val PressedScale = 0.97f
+private val UncheckedAccentRatio = 0.13f
+private val UncheckedContentAccentRatio = 0.7f
+
+@Composable
+private fun RowScope.ConnectedButton(
+    item: ConnectedButtonItem,
+    isFirst: Boolean,
+    isLast: Boolean,
+    checkedWeight: Float,
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val pressed by interactionSource.collectIsPressedAsState()
+
+    val weight by animateFloatAsState(
+        targetValue = when {
+            item.checked -> checkedWeight
+            pressed -> PressedWeight
+            else -> 1f
+        },
+        animationSpec = MaterialTheme.motionScheme.fastSpatialSpec(),
+        label = "Width weight",
+    )
+    val scale by animateFloatAsState(
+        targetValue = if (pressed) PressedScale else 1f,
+        animationSpec = MaterialTheme.motionScheme.fastSpatialSpec(),
+        label = "Pressing scale",
+    )
+
+    TonalToggleButton(
+        checked = item.checked,
+        onCheckedChange = item.onCheckedChange,
+        enabled = item.enabled,
+        shapes = item.shapes ?: connectedShapes(isFirst, isLast),
+        colors = item.colors ?: connectedColors(item.accent, item.checked),
+        contentPadding = PaddingValues(0.dp),
+        interactionSource = interactionSource,
+        modifier = item.modifier
+            // The spring may undershoot below the resting weight, but must stay positive.
+            .weight(weight.coerceAtLeast(0.1f))
+            .graphicsLayer {
+                scaleX = scale
+                scaleY = scale
+            },
+    ) { item.content() }
+}
+
+/**
+ * Default shapes of a button in a [ConnectedButtonGroup].
+ *
+ * [attachedCorner] tightens the bottom corners of the pressed/checked shapes,
+ * so the button reads as connected to a panel expanded right below it.
+ */
+internal fun connectedShapes(
+    isFirst: Boolean,
+    isLast: Boolean,
+    attachedCorner: Dp = Dp.Unspecified,
+): ToggleButtonShapes {
+    val start = if (isFirst) OuterCorner else InnerCorner
+    val end = if (isLast) OuterCorner else InnerCorner
+    return ToggleButtonShapes(
+        shape = RoundedCornerShape(
+            topStart = start,
+            bottomStart = start,
+            topEnd = end,
+            bottomEnd = end,
+        ),
+        pressedShape = RoundedCornerShape(
+            topStart = PressedCorner,
+            topEnd = PressedCorner,
+            bottomEnd = attachedCorner.takeOrElse { PressedCorner },
+            bottomStart = attachedCorner.takeOrElse { PressedCorner },
+        ),
+        checkedShape = RoundedCornerShape(
+            topStart = CheckedCorner,
+            topEnd = CheckedCorner,
+            bottomEnd = attachedCorner.takeOrElse { CheckedCorner },
+            bottomStart = attachedCorner.takeOrElse { CheckedCorner },
+        ),
+    )
+}
+
+@Composable
+private fun connectedColors(accent: Color, checked: Boolean): ToggleButtonColors {
+    val resolved = accent.takeOrElse { MaterialTheme.colorScheme.primary }
+    val containerColor by animateColorAsState(
+        targetValue = if (checked) {
+            resolved
+        } else {
+            resolved
+                .copy(alpha = UncheckedAccentRatio)
+                .compositeOver(MaterialTheme.colorScheme.surface)
+        },
+        animationSpec = MaterialTheme.motionScheme.fastEffectsSpec(),
+        label = "Container color",
+    )
+    val contentColor by animateColorAsState(
+        targetValue = if (checked) {
+            MaterialTheme.colorScheme.contentColorFor(resolved).takeOrElse { Color.White }
+        } else {
+            lerp(MaterialTheme.colorScheme.onSurface, resolved, UncheckedContentAccentRatio)
+        },
+        animationSpec = MaterialTheme.motionScheme.fastEffectsSpec(),
+        label = "Content color",
+    )
+    return ToggleButtonDefaults.tonalToggleButtonColors(
+        containerColor = containerColor,
+        contentColor = contentColor,
+        checkedContainerColor = containerColor,
+        checkedContentColor = contentColor,
+    )
 }
 
 @Preview
 @Composable
 private fun ConnectedButtonGroupPreview() {
     NeoDBYouTheme {
-        ConnectedButtonGroup(
-            optionNumber = 4,
-            selectedOption = 1,
-            onSelectedChange = {},
-            optionContent = { index ->
-                Text("Option $index")
-            },
-        )
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            // Single-select
+            var selected by remember { mutableStateOf("周") }
+            ConnectedButtonGroup(
+                options = listOf("日", "周", "月", "年"),
+                selected = selected,
+                onSelectedChange = { selected = it },
+            ) { Text(it) }
+            // Multi-select through the DSL
+            val labels = listOf("一", "二", "三", "四", "五")
+            val checked = remember { mutableStateListOf(false, true, true, false, false) }
+            ConnectedButtonGroup {
+                labels.forEachIndexed { index, label ->
+                    item(
+                        checked = checked[index],
+                        onCheckedChange = { checked[index] = it },
+                    ) { Text(label) }
+                }
+            }
+        }
     }
 }

--- a/app/src/main/kotlin/day/vitayuzu/neodb/ui/component/ConnectedButtonGroup.kt
+++ b/app/src/main/kotlin/day/vitayuzu/neodb/ui/component/ConnectedButtonGroup.kt
@@ -21,7 +21,6 @@ import androidx.compose.material3.ToggleButtonColors
 import androidx.compose.material3.ToggleButtonDefaults
 import androidx.compose.material3.ToggleButtonShapes
 import androidx.compose.material3.TonalToggleButton
-import androidx.compose.material3.contentColorFor
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
@@ -32,7 +31,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.compositeOver
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.graphics.lerp
+import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.graphics.takeOrElse
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.role
@@ -182,7 +181,6 @@ private val MultiCheckedWeight = 1.4f
 private val PressedWeight = 1.15f
 private val PressedScale = 0.97f
 private val UncheckedAccentRatio = 0.13f
-private val UncheckedContentAccentRatio = 0.7f
 
 @Composable
 private fun RowScope.ConnectedButton(
@@ -278,9 +276,9 @@ private fun connectedColors(accent: Color, checked: Boolean): ToggleButtonColors
     )
     val contentColor by animateColorAsState(
         targetValue = if (checked) {
-            MaterialTheme.colorScheme.contentColorFor(resolved).takeOrElse { Color.White }
+            resolved.contrastingContentColor()
         } else {
-            lerp(MaterialTheme.colorScheme.onSurface, resolved, UncheckedContentAccentRatio)
+            MaterialTheme.colorScheme.onSurface
         },
         animationSpec = MaterialTheme.motionScheme.fastEffectsSpec(),
         label = "Content color",
@@ -292,6 +290,10 @@ private fun connectedColors(accent: Color, checked: Boolean): ToggleButtonColors
         checkedContentColor = contentColor,
     )
 }
+
+// Black and white have equal WCAG contrast at this luminance.
+private fun Color.contrastingContentColor(): Color =
+    if (luminance() > 0.179f) Color.Black else Color.White
 
 @Preview
 @Composable

--- a/app/src/main/kotlin/day/vitayuzu/neodb/ui/page/library/LibraryPage.kt
+++ b/app/src/main/kotlin/day/vitayuzu/neodb/ui/page/library/LibraryPage.kt
@@ -14,13 +14,11 @@ import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.ToggleButtonDefaults
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -92,30 +90,21 @@ private fun LibraryContent(
                     modifier = Modifier.fillMaxWidth(),
                     contentAlignment = Alignment.Center,
                 ) {
-                    val color = listOf(
-                        MaterialTheme.colorScheme.statusColor(ShelfType.wishlist),
-                        MaterialTheme.colorScheme.statusColor(ShelfType.progress),
-                        MaterialTheme.colorScheme.statusColor(ShelfType.complete),
-                        MaterialTheme.colorScheme.statusColor(ShelfType.dropped),
-                    )
                     ConnectedButtonGroup(
-                        optionNumber = ShelfType.entries.size,
-                        selectedOption = ShelfType.entries.indexOf(uiState.selectedShelfType),
-                        onSelectedChange = { onShelfTypeChange(ShelfType.entries[it]) },
-                        colors = { index ->
-                            ToggleButtonDefaults.tonalToggleButtonColors(
-                                checkedContainerColor = color[index],
-                                checkedContentColor = Color.White,
-                            )
-                        },
-                        optionContent = { index ->
-                            Text(
-                                stringResource(ShelfType.entries[index].toR()),
-                                maxLines = 1,
-                                softWrap = false,
-                            )
-                        },
-                    )
+                        options = ShelfType.entries,
+                        selected = uiState.selectedShelfType,
+                        onSelectedChange = onShelfTypeChange,
+                        accent = { MaterialTheme.colorScheme.statusColor(it) },
+                        checkedWeight = 1.2f,
+                        modifier = Modifier.padding(horizontal = 8.dp),
+                    ) {
+                        Text(
+                            stringResource(it.toR()),
+                            maxLines = 1,
+                            softWrap = false,
+                            modifier = Modifier.padding(horizontal = 8.dp),
+                        )
+                    }
                 }
                 EntryTypeFilterChipsRow(
                     selectedEntryTypes = uiState.selectedEntryTypes,

--- a/app/src/main/kotlin/day/vitayuzu/neodb/ui/page/settings/LanguageSourcePreference.kt
+++ b/app/src/main/kotlin/day/vitayuzu/neodb/ui/page/settings/LanguageSourcePreference.kt
@@ -1,0 +1,214 @@
+@file:Suppress("MayBeConstant")
+
+package day.vitayuzu.neodb.ui.page.settings
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.background
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.relocation.BringIntoViewRequester
+import androidx.compose.foundation.relocation.bringIntoViewRequester
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.selection.selectableGroup
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.ToggleButtonColors
+import androidx.compose.material3.ToggleButtonDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.compositeOver
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.dp
+import day.vitayuzu.neodb.R
+import day.vitayuzu.neodb.data.PreferredLanguageSource
+import day.vitayuzu.neodb.ui.component.ConnectedButtonGroup
+import day.vitayuzu.neodb.ui.component.connectedShapes
+import day.vitayuzu.neodb.ui.theme.NeoDBYouTheme
+import day.vitayuzu.neodb.util.Supported_Languages
+import java.util.Locale
+
+@Composable
+fun LanguageSourcePreference(
+    selectedSource: PreferredLanguageSource,
+    onSourceChange: (PreferredLanguageSource) -> Unit,
+    selectedLanguage: String,
+    onLanguageChange: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier) {
+        val entries = PreferredLanguageSource.entries
+        ConnectedButtonGroup(Modifier.fillMaxWidth().selectableGroup()) {
+            entries.forEachIndexed { index, source ->
+                item(
+                    checked = source == selectedSource,
+                    onCheckedChange = { onSourceChange(source) },
+                    modifier = Modifier.semantics { role = Role.RadioButton },
+                    shapes = if (source == PreferredLanguageSource.User) {
+                        connectedShapes(
+                            isFirst = index == 0,
+                            isLast = index == entries.lastIndex,
+                            attachedCorner = AttachedCorner,
+                        )
+                    } else {
+                        null
+                    },
+                ) { Text(stringResource(source.toR())) }
+            }
+        }
+        AnimatedVisibility(
+            visible = selectedSource == PreferredLanguageSource.User,
+            enter = expandVertically(MaterialTheme.motionScheme.fastSpatialSpec()) +
+                fadeIn(MaterialTheme.motionScheme.fastEffectsSpec()),
+            exit = shrinkVertically(MaterialTheme.motionScheme.fastSpatialSpec()) +
+                fadeOut(MaterialTheme.motionScheme.fastEffectsSpec()),
+        ) {
+            LanguagePanel(
+                languages = Supported_Languages,
+                selected = selectedLanguage,
+                onSelect = onLanguageChange,
+                modifier = Modifier.padding(top = PanelGap),
+            )
+        }
+    }
+}
+
+@Composable
+private fun LanguagePanel(
+    languages: List<String>,
+    selected: String,
+    onSelect: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val chipColors = languages.map { languageChipColors(it == selected) }
+    // Scroll the selected chip into view when the panel opens or selection changes.
+    val selectedChipRequester = remember { BringIntoViewRequester() }
+    LaunchedEffect(selected) { selectedChipRequester.bringIntoView() }
+    ConnectedButtonGroup(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(PanelShape)
+            .background(MaterialTheme.colorScheme.primary)
+            .horizontalScroll(rememberScrollState())
+            .padding(PanelPadding)
+            .width(IntrinsicSize.Max)
+            .selectableGroup(),
+    ) {
+        languages.forEachIndexed { index, tag ->
+            item(
+                checked = tag == selected,
+                onCheckedChange = { onSelect(tag) },
+                modifier = Modifier
+                    .semantics { role = Role.RadioButton }
+                    .then(
+                        if (tag == selected) {
+                            Modifier.bringIntoViewRequester(selectedChipRequester)
+                        } else {
+                            Modifier
+                        },
+                    ),
+                colors = chipColors[index],
+            ) {
+                Text(tag.toDisplayName(), maxLines = 1)
+            }
+        }
+    }
+}
+
+/**
+ * Colors of a language button inside [LanguagePanel], inverted against the
+ * primary-colored panel: checked pops as surface, unchecked is a subtle tint.
+ */
+@Composable
+private fun languageChipColors(checked: Boolean): ToggleButtonColors {
+    val containerColor by animateColorAsState(
+        targetValue = if (checked) {
+            MaterialTheme.colorScheme.surface
+        } else {
+            MaterialTheme.colorScheme.onPrimary
+                .copy(alpha = ChipTintRatio)
+                .compositeOver(MaterialTheme.colorScheme.primary)
+        },
+        animationSpec = MaterialTheme.motionScheme.fastEffectsSpec(),
+        label = "Chip container color",
+    )
+    val contentColor by animateColorAsState(
+        targetValue = if (checked) {
+            MaterialTheme.colorScheme.primary
+        } else {
+            MaterialTheme.colorScheme.onPrimary.copy(alpha = ChipContentAlpha)
+        },
+        animationSpec = MaterialTheme.motionScheme.fastEffectsSpec(),
+        label = "Chip content color",
+    )
+    return ToggleButtonDefaults.tonalToggleButtonColors(
+        containerColor = containerColor,
+        contentColor = contentColor,
+        checkedContainerColor = containerColor,
+        checkedContentColor = contentColor,
+    )
+}
+
+/** String resource of the label for a [PreferredLanguageSource] option. */
+private fun PreferredLanguageSource.toR(): Int = when (this) {
+    PreferredLanguageSource.Server -> R.string.settings_preference_languageSource_server
+    PreferredLanguageSource.App -> R.string.settings_preference_languageSource_app
+    PreferredLanguageSource.User -> R.string.settings_preference_languageSource_user
+}
+
+/** Native display name of a BCP-47 language tag, e.g. "zh-hans" -> "简体中文". */
+private fun String.toDisplayName(): String = with(Locale.forLanguageTag(this)) {
+    getDisplayName(this).replaceFirstChar { it.titlecase(this) }
+}
+
+// Corner shared by the User button and the panel, tighter than the group's corners.
+private val AttachedCorner = 4.dp
+private val PanelCorner = 12.dp
+private val PanelGap = 4.dp
+private val PanelPadding = 8.dp
+private val PanelShape = RoundedCornerShape(
+    topStart = PanelCorner,
+    topEnd = AttachedCorner,
+    bottomEnd = PanelCorner,
+    bottomStart = PanelCorner,
+)
+private val ChipTintRatio = 0.13f
+private val ChipContentAlpha = 0.85f
+
+@PreviewLightDark
+@Composable
+private fun PreviewLanguageSourcePreference() {
+    NeoDBYouTheme {
+        Surface {
+            var source by remember { mutableStateOf(PreferredLanguageSource.User) }
+            var lang by remember { mutableStateOf("zh-hans") }
+            LanguageSourcePreference(
+                selectedSource = source,
+                onSourceChange = { source = it },
+                selectedLanguage = lang,
+                onLanguageChange = { lang = it },
+                modifier = Modifier.padding(16.dp),
+            )
+        }
+    }
+}

--- a/app/src/main/kotlin/day/vitayuzu/neodb/ui/page/settings/LanguageSourcePreference.kt
+++ b/app/src/main/kotlin/day/vitayuzu/neodb/ui/page/settings/LanguageSourcePreference.kt
@@ -41,7 +41,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import day.vitayuzu.neodb.R
-import day.vitayuzu.neodb.data.PreferredLanguageSource
+import day.vitayuzu.neodb.data.ContentLanguageSource
 import day.vitayuzu.neodb.ui.component.ConnectedButtonGroup
 import day.vitayuzu.neodb.ui.component.connectedShapes
 import day.vitayuzu.neodb.ui.theme.NeoDBYouTheme
@@ -50,21 +50,21 @@ import java.util.Locale
 
 @Composable
 fun LanguageSourcePreference(
-    selectedSource: PreferredLanguageSource,
-    onSourceChange: (PreferredLanguageSource) -> Unit,
+    selectedSource: ContentLanguageSource,
+    onSourceChange: (ContentLanguageSource) -> Unit,
     selectedLanguage: String,
     onLanguageChange: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(modifier) {
-        val entries = PreferredLanguageSource.entries
+        val entries = ContentLanguageSource.entries
         ConnectedButtonGroup(Modifier.fillMaxWidth().selectableGroup()) {
             entries.forEachIndexed { index, source ->
                 item(
                     checked = source == selectedSource,
                     onCheckedChange = { onSourceChange(source) },
                     modifier = Modifier.semantics { role = Role.RadioButton },
-                    shapes = if (source == PreferredLanguageSource.User) {
+                    shapes = if (source == ContentLanguageSource.User) {
                         connectedShapes(
                             isFirst = index == 0,
                             isLast = index == entries.lastIndex,
@@ -77,7 +77,7 @@ fun LanguageSourcePreference(
             }
         }
         AnimatedVisibility(
-            visible = selectedSource == PreferredLanguageSource.User,
+            visible = selectedSource == ContentLanguageSource.User,
             enter = expandVertically(MaterialTheme.motionScheme.fastSpatialSpec()) +
                 fadeIn(MaterialTheme.motionScheme.fastEffectsSpec()),
             exit = shrinkVertically(MaterialTheme.motionScheme.fastSpatialSpec()) +
@@ -169,11 +169,11 @@ private fun languageChipColors(checked: Boolean): ToggleButtonColors {
     )
 }
 
-/** String resource of the label for a [PreferredLanguageSource] option. */
-private fun PreferredLanguageSource.toR(): Int = when (this) {
-    PreferredLanguageSource.Server -> R.string.settings_preference_languageSource_server
-    PreferredLanguageSource.App -> R.string.settings_preference_languageSource_app
-    PreferredLanguageSource.User -> R.string.settings_preference_languageSource_user
+/** String resource of the label for a [ContentLanguageSource] option. */
+private fun ContentLanguageSource.toR(): Int = when (this) {
+    ContentLanguageSource.Server -> R.string.settings_preference_languageSource_server
+    ContentLanguageSource.App -> R.string.settings_preference_languageSource_app
+    ContentLanguageSource.User -> R.string.settings_preference_languageSource_user
 }
 
 /** Native display name of a BCP-47 language tag, e.g. "zh-hans" -> "简体中文". */
@@ -200,7 +200,7 @@ private val ChipContentAlpha = 0.85f
 private fun PreviewLanguageSourcePreference() {
     NeoDBYouTheme {
         Surface {
-            var source by remember { mutableStateOf(PreferredLanguageSource.User) }
+            var source by remember { mutableStateOf(ContentLanguageSource.User) }
             var lang by remember { mutableStateOf("zh-hans") }
             LanguageSourcePreference(
                 selectedSource = source,

--- a/app/src/main/kotlin/day/vitayuzu/neodb/ui/page/settings/SelectablePreference.kt
+++ b/app/src/main/kotlin/day/vitayuzu/neodb/ui/page/settings/SelectablePreference.kt
@@ -1,82 +1,91 @@
 package day.vitayuzu.neodb.ui.page.settings
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import day.vitayuzu.neodb.ui.component.ConnectedButtonGroup
-import day.vitayuzu.neodb.ui.theme.NeoDBYouTheme
+import day.vitayuzu.neodb.ui.component.ConnectedButtonGroupScope
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
-@Composable
-fun SelectablePreference(
-    optionNumber: Int,
-    selectedOption: Int,
-    onSelectedChange: (Int) -> Unit,
-    shape: Shape,
-    modifier: Modifier = Modifier,
-    color: Color = CardDefaults.cardColors().containerColor,
-    title: @Composable () -> Unit = {},
-    optionContent: @Composable (Int) -> Unit = {},
-) {
-    Card(
-        modifier = modifier,
-        shape = shape,
-        colors = CardDefaults.cardColors(containerColor = color),
+object SelectablePreferenceCard {
+    @Composable
+    fun <T> Single(
+        options: List<T>,
+        selected: T,
+        onSelectedChange: (T) -> Unit,
+        shape: Shape,
+        modifier: Modifier = Modifier,
+        color: Color = CardDefaults.cardColors().containerColor,
+        title: @Composable () -> Unit = {},
+        optionContent: @Composable (T) -> Unit = {},
     ) {
-        title()
+        Card(
+            modifier = modifier,
+            shape = shape,
+            colors = CardDefaults.cardColors(containerColor = color),
+        ) {
+            val scrollState = rememberScrollState()
+            LaunchedEffect(scrollState, selected) {
+                if (options.first() == selected) {
+                    scrollState.animateScrollTo(0)
+                } else if (options.last() == selected) {
+                    scrollState.animateScrollTo(scrollState.maxValue)
+                }
+            }
 
-        val scrollState = rememberScrollState()
-        LaunchedEffect(scrollState, selectedOption) {
-            if (selectedOption == 0) {
-                scrollState.animateScrollTo(0)
-            } else if (selectedOption == optionNumber - 1) {
-                scrollState.animateScrollTo(scrollState.maxValue)
+            title()
+            BoxWithConstraints {
+                ConnectedButtonGroup(
+                    options = options,
+                    selected = selected,
+                    onSelectedChange = onSelectedChange,
+                    optionContent = optionContent,
+                    checkedWeight = 1.4f,
+                    modifier = Modifier
+                        .horizontalScroll(scrollState)
+                        .padding(start = 56.dp, end = 8.dp, bottom = 8.dp)
+                        .width(IntrinsicSize.Max)
+                        .widthIn(min = maxWidth - 64.dp),
+                )
             }
         }
-        ConnectedButtonGroup(
-            optionNumber = optionNumber,
-            selectedOption = selectedOption,
-            onSelectedChange = onSelectedChange,
-            optionContent = optionContent,
-            modifier = Modifier
-                .padding(start = 56.dp, end = 8.dp)
-                .horizontalScroll(scrollState),
-        )
     }
-}
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
-@Preview
-@Composable
-private fun SelectablePreferencePreview() {
-    NeoDBYouTheme {
-        SelectablePreference(
-            optionNumber = 4,
-            selectedOption = 1,
-            onSelectedChange = {},
-            shape = MaterialTheme.shapes.medium,
-            title = {
-                Text(
-                    text = "Select Option",
-                    modifier = Modifier.padding(16.dp),
-                    style = MaterialTheme.typography.titleMedium,
-                )
-            },
-            optionContent = { index ->
-                Text("Option $index")
-            },
-        )
+    @Composable
+    fun Multi(
+        modifier: Modifier = Modifier,
+        shape: Shape,
+        title: @Composable () -> Unit = {},
+        content: ConnectedButtonGroupScope.() -> Unit,
+    ) {
+        Card(
+            shape = shape,
+            modifier = modifier,
+        ) {
+            title()
+            ConnectedButtonGroup(
+                columns = 4,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(MaterialTheme.colorScheme.surfaceContainer)
+                    .padding(start = 56.dp, bottom = 8.dp, end = 8.dp),
+            ) {
+                content()
+            }
+        }
     }
 }

--- a/app/src/main/kotlin/day/vitayuzu/neodb/ui/page/settings/SettingsPage.kt
+++ b/app/src/main/kotlin/day/vitayuzu/neodb/ui/page/settings/SettingsPage.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -36,9 +35,7 @@ import androidx.compose.material3.BadgedBox
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
-import androidx.compose.material3.FilterChip
-import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.ListItemDefaults
@@ -48,13 +45,14 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
-import androidx.compose.material3.ToggleButtonDefaults
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -73,6 +71,7 @@ import day.vitayuzu.neodb.BuildConfig
 import day.vitayuzu.neodb.OauthActivity
 import day.vitayuzu.neodb.R
 import day.vitayuzu.neodb.data.AppSettings
+import day.vitayuzu.neodb.data.PreferredLanguageSource
 import day.vitayuzu.neodb.ui.theme.AppShapeDefaults
 import day.vitayuzu.neodb.ui.theme.NeoDBYouTheme
 import day.vitayuzu.neodb.util.AppNavigator
@@ -121,6 +120,7 @@ fun SettingsPage(
                     settings = uiState.appSettings,
                     onChangeShelfType = viewModel::onChangeShelfType,
                     onChangeEntryType = viewModel::onChangeEntryTypes,
+                    onChangeContentLang = viewModel::onChangePreferredLanguageSource,
                     onToggleCheckUpdate = viewModel::onToggleCheckUpdate,
                 )
                 AboutCard(
@@ -238,14 +238,13 @@ private fun UserProfilePart(
     }
 }
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
-@Preview
 @Composable
 private fun SettingsCard(
     modifier: Modifier = Modifier,
     settings: AppSettings = AppSettings(),
     onChangeShelfType: (ShelfType) -> Unit = {},
     onChangeEntryType: (List<EntryType>) -> Unit = {},
+    onChangeContentLang: (source: PreferredLanguageSource, lang: String?) -> Unit = { _, _ -> },
     onToggleCheckUpdate: (Boolean) -> Unit = {},
 ) {
     Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(2.dp)) {
@@ -256,97 +255,110 @@ private fun SettingsCard(
         val itemColors = ListItemDefaults.colors(
             containerColor = MaterialTheme.colorScheme.surfaceContainer,
         )
-        SelectablePreference(
+        SelectablePreferenceCard.Single(
+            options = ShelfType.entries,
+            selected = settings.libraryShelfType,
+            onSelectedChange = { onChangeShelfType(it) },
             color = MaterialTheme.colorScheme.surfaceContainer,
-            optionNumber = ShelfType.entries.size,
-            selectedOption = ShelfType.entries.indexOf(settings.libraryShelfType),
-            onSelectedChange = { onChangeShelfType(ShelfType.entries[it]) },
             shape = AppShapeDefaults.topListItemShape,
             title = {
                 ListItem(
                     leadingContent = { Icon(Icons.Default.DateRange, null) },
-                    headlineContent = {
-                        Text(stringResource(R.string.settings_preference_shelfType))
-                    },
                     supportingContent = {
                         Text(stringResource(R.string.settings_preference_shelfType_support))
                     },
                     colors = itemColors,
-                )
-            },
-            optionContent = {
-                Text(stringResource(ShelfType.entries[it].toR()))
-            },
-        )
-        Card(shape = AppShapeDefaults.middleListItemShape) {
-            val selectedTypes =
-                remember {
-                    mutableStateListOf<EntryType>().apply {
-                        settings.homeTrendingTypes.takeIf { it.isNotEmpty() }?.let {
-                            addAll(settings.homeTrendingTypes)
-                        } ?: addAll(EntryType.entries.take(6))
-                    }
+                ) {
+                    Text(stringResource(R.string.settings_preference_shelfType))
                 }
-            ListItem(
-                leadingContent = { Icon(Icons.Default.Home, null) },
-                headlineContent = {
-                    Text(stringResource(R.string.settings_preference_entryType))
-                },
-                supportingContent = {
-                    Text(stringResource(R.string.settings_preference_entryType_support))
-                },
-                colors = itemColors,
-            )
-            FlowRow(
-                horizontalArrangement = Arrangement.spacedBy(2.dp),
-                modifier = Modifier
-                    .background(MaterialTheme.colorScheme.surfaceContainer)
-                    .fillMaxWidth()
-                    .padding(start = 56.dp),
-            ) {
-                EntryType.entries.take(6).forEach {
-                    FilterChip(
-                        selected = selectedTypes.contains(it),
-                        onClick = {
-                            if (selectedTypes.contains(it)) {
-                                selectedTypes.remove(it)
-                            } else {
-                                selectedTypes.add(it)
-                            }
-                            onChangeEntryType(selectedTypes)
-                        },
-                        label = { Text(stringResource(it.toR())) },
-                        colors = FilterChipDefaults.filterChipColors().copy(
-                            containerColor = ToggleButtonDefaults
-                                .tonalToggleButtonColors()
-                                .containerColor,
-                            labelColor = ToggleButtonDefaults
-                                .tonalToggleButtonColors()
-                                .contentColor,
-                            selectedContainerColor = ToggleButtonDefaults
-                                .tonalToggleButtonColors()
-                                .checkedContainerColor,
-                            selectedLabelColor = ToggleButtonDefaults
-                                .tonalToggleButtonColors()
-                                .checkedContentColor,
-                        ),
+            },
+        ) {
+            Text(stringResource(it.toR()), modifier = Modifier.padding(horizontal = 12.dp))
+        }
+
+        val selectedTypes =
+            remember {
+                mutableStateListOf<EntryType>().apply {
+                    settings.homeTrendingTypes.takeIf { it.isNotEmpty() }?.let {
+                        addAll(settings.homeTrendingTypes)
+                    } ?: addAll(EntryType.entries.take(6))
+                }
+            }
+        SelectablePreferenceCard.Multi(
+            shape = AppShapeDefaults.middleListItemShape,
+            title = {
+                ListItem(
+                    leadingContent = { Icon(Icons.Default.Home, null) },
+                    supportingContent = {
+                        Text(stringResource(R.string.settings_preference_entryType_support))
+                    },
+                    colors = itemColors,
+                ) {
+                    Text(
+                        stringResource(R.string.settings_preference_entryType),
+                    )
+                }
+            },
+        ) {
+            EntryType.entries.take(6).forEach { entryType ->
+                item(
+                    checked = entryType in selectedTypes,
+                    onCheckedChange = {
+                        if (selectedTypes.contains(entryType)) {
+                            selectedTypes.remove(entryType)
+                        } else {
+                            selectedTypes.add(entryType)
+                        }
+                        onChangeEntryType(selectedTypes)
+                    },
+                ) {
+                    Text(
+                        stringResource(entryType.toR()),
+                        modifier = Modifier.padding(horizontal = 8.dp),
                     )
                 }
             }
         }
+
+        // Content Language
+        Card(
+            shape = AppShapeDefaults.middleListItemShape,
+            colors = CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.surfaceContainer,
+            ),
+        ) {
+            ListItem(
+                colors = itemColors,
+                leadingContent = { Icon(painterResource(R.drawable.internet_outline), null) },
+                supportingContent = {
+                    Text(stringResource(R.string.settings_preference_languageSource_support))
+                },
+            ) {
+                Text(stringResource(R.string.settings_preference_languageSource))
+            }
+            LanguageSourcePreference(
+                selectedSource = settings.preferredLanguageSource,
+                onSourceChange = { onChangeContentLang(it, settings.contentUserLanguage) },
+                selectedLanguage = settings.contentUserLanguage,
+                onLanguageChange = { onChangeContentLang(PreferredLanguageSource.User, it) },
+                modifier = Modifier.padding(start = 56.dp, end = 8.dp, bottom = 8.dp),
+            )
+        }
+
         // Check Update Switch
         Card(shape = AppShapeDefaults.bottomListItemShape) {
             ListItem(
                 colors = itemColors,
                 leadingContent = { Icon(Icons.Default.Refresh, null) },
-                headlineContent = { Text(stringResource(R.string.settings_preference_update)) },
                 trailingContent = {
                     Switch(
                         checked = settings.checkUpdate,
                         onCheckedChange = onToggleCheckUpdate,
                     )
                 },
-            )
+            ) {
+                Text(stringResource(R.string.settings_preference_update))
+            }
         }
     }
 }
@@ -370,15 +382,11 @@ private fun AboutCard(
             )
             // Version
             ListItem(
-                colors = itemColors,
-                headlineContent = { Text(stringResource(R.string.settings_about_version)) },
-                trailingContent = {
-                    Row(
-                        horizontalArrangement = Arrangement.spacedBy(4.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        if (newVersionUrl != null) Text("Go to release page", Modifier.alpha(.6f))
-                        Text(BuildConfig.VERSION_NAME)
+                modifier = Modifier.clickable {
+                    if (newVersionUrl != null) {
+                        intent.launchUrl(context, newVersionUrl.toUri().toHttpUri())
+                    } else {
+                        checkUpdate()
                     }
                 },
                 leadingContent = {
@@ -390,29 +398,37 @@ private fun AboutCard(
                         Icon(Icons.Default.Info, null)
                     }
                 },
-                modifier = Modifier.clickable {
-                    if (newVersionUrl != null) {
-                        intent.launchUrl(context, newVersionUrl.toUri().toHttpUri())
-                    } else {
-                        checkUpdate()
+                trailingContent = {
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(4.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        if (newVersionUrl != null) Text("Go to release page", Modifier.alpha(.6f))
+                        Text(BuildConfig.VERSION_NAME)
                     }
                 },
+                overlineContent = null,
+                supportingContent = null,
+                colors = itemColors,
+                elevation = ListItemDefaults.elevation(ListItemDefaults.Elevation),
+                content = { Text(stringResource(R.string.settings_about_version)) },
             )
             // Developer
             ListItem(
-                colors = itemColors,
-                headlineContent = { Text(stringResource(R.string.settings_about_developer)) },
-                trailingContent = { Text("@heddxh(Yuzu Vita)") },
+                modifier = Modifier,
                 leadingContent = { Icon(Icons.Default.AccountCircle, null) },
+                trailingContent = { Text("@heddxh(Yuzu Vita)") },
+                overlineContent = null,
+                supportingContent = null,
+                colors = itemColors,
+                elevation = ListItemDefaults.elevation(ListItemDefaults.Elevation),
+                content = { Text(stringResource(R.string.settings_about_developer)) },
             )
             ListItem(
-                colors = itemColors,
-                headlineContent = { Text("GitHub") },
-                trailingContent = {
-                    Icon(
-                        painterResource(R.drawable.outline_arrow_outward_24),
-                        "Go to GitHub repo",
-                        Modifier.size(16.dp),
+                modifier = Modifier.clickable {
+                    intent.launchUrl(
+                        context,
+                        "https://github.com/heddxh/NeoDB-You".toUri(),
                     )
                 },
                 leadingContent = {
@@ -424,16 +440,22 @@ private fun AboutCard(
                         Modifier.size(24.dp).padding(2.dp),
                     )
                 },
-                modifier = Modifier.clickable {
-                    intent.launchUrl(
-                        context,
-                        "https://github.com/heddxh/NeoDB-You".toUri(),
+                trailingContent = {
+                    Icon(
+                        painterResource(R.drawable.outline_arrow_outward_24),
+                        "Go to GitHub repo",
+                        Modifier.size(16.dp),
                     )
                 },
+                overlineContent = null,
+                supportingContent = null,
+                colors = itemColors,
+                elevation = ListItemDefaults.elevation(ListItemDefaults.Elevation),
+                content = { Text("GitHub") },
             )
             ListItem(
-                colors = itemColors,
-                headlineContent = { Text(stringResource(R.string.settings_about_license)) },
+                modifier = Modifier.clickable { appNavigator goto AppNavigator.License },
+                leadingContent = { Icon(painterResource(R.drawable.baseline_balance_24), null) },
                 trailingContent = {
                     Icon(
                         Icons.AutoMirrored.Filled.ArrowForward,
@@ -441,8 +463,11 @@ private fun AboutCard(
                         Modifier.size(16.dp),
                     )
                 },
-                leadingContent = { Icon(painterResource(R.drawable.baseline_balance_24), null) },
-                modifier = Modifier.clickable { appNavigator goto AppNavigator.License },
+                overlineContent = null,
+                supportingContent = null,
+                colors = itemColors,
+                elevation = ListItemDefaults.elevation(ListItemDefaults.Elevation),
+                content = { Text(stringResource(R.string.settings_about_license)) },
             )
         }
     }
@@ -468,37 +493,69 @@ private fun ExperimentalCard(
                 headlineColor = MaterialTheme.colorScheme.onErrorContainer,
             )
             ListItem(
-                colors = itemColors,
-                headlineContent = {
-                    Text(stringResource(R.string.settings_experimental_clearAuth))
-                },
+                modifier = Modifier.clickable(onClick = onClearAuthData),
+                leadingContent = null,
+                trailingContent = null,
+                overlineContent = null,
                 supportingContent = {
                     Text(stringResource(R.string.settings_experimental_clearAuth_supportText))
                 },
-                modifier = Modifier.clickable(onClick = onClearAuthData),
+                colors = itemColors,
+                elevation = ListItemDefaults.elevation(ListItemDefaults.Elevation),
+                content = {
+                    Text(stringResource(R.string.settings_experimental_clearAuth))
+                },
             )
             ListItem(
-                colors = itemColors,
-                headlineContent = {
-                    Text(stringResource(R.string.settings_experimental_verbose))
-                },
-                supportingContent = {
-                    Text(stringResource(R.string.settings_experimental_verbose_supportText))
-                },
+                modifier = Modifier,
+                leadingContent = null,
                 trailingContent = {
                     Switch(checked = appSettings.verboseLog, onCheckedChange = onToggleVerboseLog)
                 },
+                overlineContent = null,
+                supportingContent = {
+                    Text(stringResource(R.string.settings_experimental_verbose_supportText))
+                },
+                colors = itemColors,
+                elevation = ListItemDefaults.elevation(ListItemDefaults.Elevation),
+                content = {
+                    Text(stringResource(R.string.settings_experimental_verbose))
+                },
             )
             ListItem(
-                colors = itemColors,
-                headlineContent = {
-                    Text(stringResource(R.string.settings_experimental_print))
-                },
                 modifier = Modifier.clickable {
                     Log.d("ExperimentalCard", appSettings.toString())
                 },
+                leadingContent = null,
+                trailingContent = null,
+                overlineContent = null,
+                supportingContent = null,
+                colors = itemColors,
+                elevation = ListItemDefaults.elevation(ListItemDefaults.Elevation),
+                content = {
+                    Text(stringResource(R.string.settings_experimental_print))
+                },
             )
         }
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewSettingsCard() {
+    NeoDBYouTheme {
+        var settings by remember { mutableStateOf(AppSettings()) }
+        SettingsCard(
+            settings = settings,
+            onChangeShelfType = {
+                settings = settings.copy(libraryShelfType = it)
+            },
+            onChangeContentLang = { source, lang ->
+                settings
+                    .copy(preferredLanguageSource = source)
+                    .let { settings = it }
+            },
+        )
     }
 }
 

--- a/app/src/main/kotlin/day/vitayuzu/neodb/ui/page/settings/SettingsPage.kt
+++ b/app/src/main/kotlin/day/vitayuzu/neodb/ui/page/settings/SettingsPage.kt
@@ -71,7 +71,7 @@ import day.vitayuzu.neodb.BuildConfig
 import day.vitayuzu.neodb.OauthActivity
 import day.vitayuzu.neodb.R
 import day.vitayuzu.neodb.data.AppSettings
-import day.vitayuzu.neodb.data.PreferredLanguageSource
+import day.vitayuzu.neodb.data.ContentLanguageSource
 import day.vitayuzu.neodb.ui.theme.AppShapeDefaults
 import day.vitayuzu.neodb.ui.theme.NeoDBYouTheme
 import day.vitayuzu.neodb.util.AppNavigator
@@ -120,7 +120,7 @@ fun SettingsPage(
                     settings = uiState.appSettings,
                     onChangeShelfType = viewModel::onChangeShelfType,
                     onChangeEntryType = viewModel::onChangeEntryTypes,
-                    onChangeContentLang = viewModel::onChangePreferredLanguageSource,
+                    onChangeContentLang = viewModel::onChangeContentLanguage,
                     onToggleCheckUpdate = viewModel::onToggleCheckUpdate,
                 )
                 AboutCard(
@@ -244,7 +244,7 @@ private fun SettingsCard(
     settings: AppSettings = AppSettings(),
     onChangeShelfType: (ShelfType) -> Unit = {},
     onChangeEntryType: (List<EntryType>) -> Unit = {},
-    onChangeContentLang: (source: PreferredLanguageSource, lang: String?) -> Unit = { _, _ -> },
+    onChangeContentLang: (source: ContentLanguageSource, lang: String) -> Unit = { _, _ -> },
     onToggleCheckUpdate: (Boolean) -> Unit = {},
 ) {
     Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(2.dp)) {
@@ -337,10 +337,10 @@ private fun SettingsCard(
                 Text(stringResource(R.string.settings_preference_languageSource))
             }
             LanguageSourcePreference(
-                selectedSource = settings.preferredLanguageSource,
-                onSourceChange = { onChangeContentLang(it, settings.contentUserLanguage) },
-                selectedLanguage = settings.contentUserLanguage,
-                onLanguageChange = { onChangeContentLang(PreferredLanguageSource.User, it) },
+                selectedSource = settings.contentLanguageSource,
+                onSourceChange = { onChangeContentLang(it, settings.customContentLanguage) },
+                selectedLanguage = settings.customContentLanguage,
+                onLanguageChange = { onChangeContentLang(ContentLanguageSource.User, it) },
                 modifier = Modifier.padding(start = 56.dp, end = 8.dp, bottom = 8.dp),
             )
         }
@@ -552,7 +552,7 @@ private fun PreviewSettingsCard() {
             },
             onChangeContentLang = { source, lang ->
                 settings
-                    .copy(preferredLanguageSource = source)
+                    .copy(contentLanguageSource = source)
                     .let { settings = it }
             },
         )

--- a/app/src/main/kotlin/day/vitayuzu/neodb/ui/page/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/day/vitayuzu/neodb/ui/page/settings/SettingsViewModel.kt
@@ -11,6 +11,7 @@ import day.vitayuzu.neodb.data.AppSettingsManager.Companion.LIBRARY_SHELF_TYPE
 import day.vitayuzu.neodb.data.AppSettingsManager.Companion.VERBOSE_LOG
 import day.vitayuzu.neodb.data.AuthRepository
 import day.vitayuzu.neodb.data.OtherRepository
+import day.vitayuzu.neodb.data.PreferredLanguageSource
 import day.vitayuzu.neodb.data.UserPreference
 import day.vitayuzu.neodb.data.UserPreferenceManager
 import day.vitayuzu.neodb.data.schema.UserSchema
@@ -133,6 +134,16 @@ class SettingsViewModel @Inject constructor(
     fun onChangeEntryTypes(types: List<EntryType>) {
         viewModelScope.launch {
             appSettingsManager.store(HOME_TRENDING_TYPES, types)
+        }
+    }
+
+    fun onChangePreferredLanguageSource(to: PreferredLanguageSource, lang: String?) {
+        val userLanguage = requireNotNull(lang)
+        viewModelScope.launch {
+            appSettingsManager.storeContentLanguagePreference(
+                source = to,
+                userLanguage = userLanguage,
+            )
         }
     }
 

--- a/app/src/main/kotlin/day/vitayuzu/neodb/ui/page/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/day/vitayuzu/neodb/ui/page/settings/SettingsViewModel.kt
@@ -11,7 +11,7 @@ import day.vitayuzu.neodb.data.AppSettingsManager.Companion.LIBRARY_SHELF_TYPE
 import day.vitayuzu.neodb.data.AppSettingsManager.Companion.VERBOSE_LOG
 import day.vitayuzu.neodb.data.AuthRepository
 import day.vitayuzu.neodb.data.OtherRepository
-import day.vitayuzu.neodb.data.PreferredLanguageSource
+import day.vitayuzu.neodb.data.ContentLanguageSource
 import day.vitayuzu.neodb.data.UserPreference
 import day.vitayuzu.neodb.data.UserPreferenceManager
 import day.vitayuzu.neodb.data.schema.UserSchema
@@ -137,12 +137,11 @@ class SettingsViewModel @Inject constructor(
         }
     }
 
-    fun onChangePreferredLanguageSource(to: PreferredLanguageSource, lang: String?) {
-        val userLanguage = requireNotNull(lang)
+    fun onChangeContentLanguage(to: ContentLanguageSource, customLanguage: String) {
         viewModelScope.launch {
             appSettingsManager.storeContentLanguagePreference(
                 source = to,
-                userLanguage = userLanguage,
+                customLanguage = customLanguage,
             )
         }
     }

--- a/app/src/main/kotlin/day/vitayuzu/neodb/ui/theme/Theme.kt
+++ b/app/src/main/kotlin/day/vitayuzu/neodb/ui/theme/Theme.kt
@@ -6,6 +6,7 @@ import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.MaterialExpressiveTheme
 import androidx.compose.material3.MotionScheme
+import androidx.compose.material3.Shapes
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
@@ -90,6 +91,7 @@ fun NeoDBYouTheme(
         colorScheme = colorScheme,
         typography = Typography,
         motionScheme = MotionScheme.expressive(),
+        shapes = Shapes(),
         content = content,
     )
 }

--- a/app/src/main/kotlin/day/vitayuzu/neodb/util/Constant.kt
+++ b/app/src/main/kotlin/day/vitayuzu/neodb/util/Constant.kt
@@ -9,7 +9,7 @@ const val USER_PREFERENCES = "user_preferences"
 /**
  * Extract from [settings.py](https://raw.githubusercontent.com/neodb-social/neodb/main/neodb/boofilsic/settings.py)
  *
- * NOTE: Subtract primary language subtag for post; Pass it as Accept-Language to get localized metadata
+ * Pass a supported tag as Accept-Language to get localized item metadata.
  */
 val Supported_Languages = listOf(
     "da",

--- a/app/src/main/kotlin/day/vitayuzu/neodb/util/Locale.kt
+++ b/app/src/main/kotlin/day/vitayuzu/neodb/util/Locale.kt
@@ -1,0 +1,19 @@
+package day.vitayuzu.neodb.util
+
+import java.util.Locale
+
+/**
+ * Best matching tag in [Supported_Languages] for this locale (RFC 4647 lookup),
+ * falling back to script/region inference for Chinese and "en" otherwise.
+ */
+fun Locale.toSupportedTag(): String {
+    val matched = Locale.lookupTag(
+        Locale.LanguageRange.parse(toLanguageTag()),
+        Supported_Languages,
+    )
+    return matched ?: when {
+        language != "zh" -> "en"
+        script == "Hant" || country in setOf("TW", "HK", "MO") -> "zh-hant"
+        else -> "zh-hans"
+    }
+}

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -51,7 +51,7 @@
     <string name="settings_preference_entryType">主页趋势</string>
     <string name="settings_preference_entryType_support">设置希望显示在主页上的趋势类型。</string>
     <string name="settings_preference_languageSource">内容语言</string>
-    <string name="settings_preference_languageSource_support">条目信息与发文的首选语言。</string>
+    <string name="settings_preference_languageSource_support">条目信息的首选语言。</string>
     <string name="settings_preference_languageSource_server">服务器</string>
     <string name="settings_preference_languageSource_app">应用</string>
     <string name="settings_preference_languageSource_user">自定义</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -50,6 +50,11 @@
     <string name="settings_preference_shelfType_support">设定标记页中默认显示的标记状态。</string>
     <string name="settings_preference_entryType">主页趋势</string>
     <string name="settings_preference_entryType_support">设置希望显示在主页上的趋势类型。</string>
+    <string name="settings_preference_languageSource">内容语言</string>
+    <string name="settings_preference_languageSource_support">条目信息与发文的首选语言。</string>
+    <string name="settings_preference_languageSource_server">服务器</string>
+    <string name="settings_preference_languageSource_app">应用</string>
+    <string name="settings_preference_languageSource_user">自定义</string>
     <string name="detail_delete_mark">删除标记</string>
     <string name="detail_delete_mark_confirm">确认删除标记？</string>
     <string name="confirm">确定</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -51,6 +51,11 @@
     <string name="settings_preference_shelfType_support">Set default mark status showing in library page.</string>
     <string name="settings_preference_entryType">Home trending sections</string>
     <string name="settings_preference_entryType_support">Set which sections you want to see in home page.</string>
+    <string name="settings_preference_languageSource">Content language</string>
+    <string name="settings_preference_languageSource_support">Preferred language for item info and posts.</string>
+    <string name="settings_preference_languageSource_server">Server</string>
+    <string name="settings_preference_languageSource_app">App</string>
+    <string name="settings_preference_languageSource_user">Custom</string>
     <string name="detail_delete_mark">Delete mark</string>
     <string name="detail_delete_mark_confirm">Are you sure to delete this mark?</string>
     <string name="confirm">Confirm</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -52,7 +52,7 @@
     <string name="settings_preference_entryType">Home trending sections</string>
     <string name="settings_preference_entryType_support">Set which sections you want to see in home page.</string>
     <string name="settings_preference_languageSource">Content language</string>
-    <string name="settings_preference_languageSource_support">Preferred language for item info and posts.</string>
+    <string name="settings_preference_languageSource_support">Preferred language for item info.</string>
     <string name="settings_preference_languageSource_server">Server</string>
     <string name="settings_preference_languageSource_app">App</string>
     <string name="settings_preference_languageSource_user">Custom</string>


### PR DESCRIPTION
## Summary
- add Server, App, and Custom content-language preferences for localized item metadata
- persist language source and custom language atomically with safe DataStore defaults and decoding
- resolve the effective language for every request and wait for server preference readiness on cold start
- narrow settings copy to item information only

## Verification
- `./gradlew :app:compileDebugKotlin`
- `./gradlew :app:compileDebugKotlin --rerun-tasks`